### PR TITLE
Remove "allowBackup" from this file

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         >
         <activity


### PR DESCRIPTION
allowBackup=true collides with apps that try to include AboutLibraries and use allowBackup=false on their own manifest. Gradle Build V > 0.10.0 will fail. The solution suggested by gradle (add tools:replace="allowBackup" to application element) does work, but is only a workaround.
