### PR TITLE
Remove label from AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,12 +2,8 @@
     package="com.tundem.aboutlibraries"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application
-        android:label="@string/app_name"
-        >
-        <activity
-            android:name="com.tundem.aboutlibraries.ui.LibsActivity">
-        </activity>
+    <application>
+        <activity android:name="com.tundem.aboutlibraries.ui.LibsActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Because a) it's not needed for a library and b) Gradle sometimes fails to build and the solution suggested by gradle (add tools:replace="label" to application element) does not work.
