### PR TITLE
New Libraries and fix for text from Library A appearing on Library B's card

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
@@ -247,7 +247,7 @@ public class LibsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
         this.header = false;
     }
 
-    public class HeaderViewHolder extends RecyclerView.ViewHolder {
+    public static class HeaderViewHolder extends RecyclerView.ViewHolder {
         ImageView aboutIcon;
         TextView aboutAppName;
         TextView aboutVersion;
@@ -266,7 +266,7 @@ public class LibsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
         }
     }
 
-    public class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         View card;
 
         TextView libraryName;

--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
@@ -247,7 +247,7 @@ public class LibsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
         this.header = false;
     }
 
-    public static class HeaderViewHolder extends RecyclerView.ViewHolder {
+    public class HeaderViewHolder extends RecyclerView.ViewHolder {
         ImageView aboutIcon;
         TextView aboutAppName;
         TextView aboutVersion;
@@ -266,7 +266,7 @@ public class LibsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
         }
     }
 
-    public static class ViewHolder extends RecyclerView.ViewHolder {
+    public class ViewHolder extends RecyclerView.ViewHolder {
         View card;
 
         TextView libraryName;

--- a/library/src/main/res/values/library_appcompat_strings.xml
+++ b/library/src/main/res/values/library_appcompat_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_int_AppCompat">year;owner</string>
+	<string name="library_AppCompat_author">AOSP</string>
+	<string name="library_AppCompat_authorWebsite">https://source.android.com/</string>
+	<string name="library_AppCompat_classPath">com.android.support.v7</string>
+	<string name="library_AppCompat_libraryName">AppCompat Library</string>
+	<string name="library_AppCompat_libraryDescription">This library adds support for the Action Bar user interface design pattern. This library includes support for material design user interface implementations.</string>
+	<string name="library_AppCompat_libraryWebsite">https://developer.android.com/tools/support-library/features.html#v7</string>
+	<string name="library_AppCompat_licenseId">apache_2_0</string>
+	<string name="library_AppCompat_isOpenSource">false</string>
+	<string name="library_AppCompat_repositoryLink"></string>
+	<!-- Custom variables section -->
+	<string name="library_AppCompat_owner">AOSP</string>
+	<string name="library_AppCompat_year">2015</string>
+</resources> 

--- a/library/src/main/res/values/library_crashlytics_strings.xml
+++ b/library/src/main/res/values/library_crashlytics_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="define_int_Crashlytics">year;owner</string>
+	<string name="library_Crashlytics_author">Twitter</string>
+	<string name="library_Crashlytics_authorWebsite">http://www.twitter.com/</string>
+	<string name="library_Crashlytics_classPath">com.crashlytics.sdk.android</string>
+	<string name="library_Crashlytics_libraryName">Crashlytics</string>
+	<string name="library_Crashlytics_libraryDescription">The Crashlytics Kit for Android provides simple APIs for reporting crashes.</string>
+	<string name="library_Crashlytics_libraryWebsite">https://www.fabric.io/</string>
+	<string name="library_Crashlytics_licenseId">apache_2_0</string>
+	<string name="library_Crashlytics_isOpenSource">false</string>
+	<string name="library_Crashlytics_repositoryLink"></string>
+	<!-- Custom variables section -->
+	<string name="library_Crashlytics_owner">Twitter</string>
+	<string name="library_Crashlytics_year">2015</string>
+</resources> 

--- a/library/src/main/res/values/library_facebook_strings.xml
+++ b/library/src/main/res/values/library_facebook_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="define_int_Facebook">year;owner</string>
+	<string name="library_Facebook_author">Facebook</string>
+	<string name="library_Facebook_authorWebsite">http://www.facebook.com/</string>
+	<string name="library_Facebook_classPath">com.facebook.android</string>
+	<string name="library_Facebook_libraryName">Facebook</string>
+	<string name="library_Facebook_libraryDescription">Integrate Android apps with Facebook Platform.</string>
+	<string name="library_Facebook_libraryWebsite">https://developers.facebook.com/docs/android</string>
+	<string name="library_Facebook_licenseId">apache_2_0</string>
+	<string name="library_Facebook_isOpenSource">false</string>
+	<string name="library_Facebook_repositoryLink"></string>
+	<!-- Custom variables section -->
+	<string name="library_Facebook_owner">Facebook</string>
+	<string name="library_Facebook_year">2015</string>
+</resources> 

--- a/library/src/main/res/values/library_googleplayservices_strings.xml
+++ b/library/src/main/res/values/library_googleplayservices_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="define_int_GooglePlayServices">year;owner</string>
+	<string name="library_GooglePlayServices_author">AOSP</string>
+	<string name="library_GooglePlayServices_authorWebsite">https://source.android.com/</string>
+	<string name="library_GooglePlayServices_classPath">com.google.android.gms</string>
+	<string name="library_GooglePlayServices_libraryName">Google Play Services</string>
+	<string name="library_GooglePlayServices_libraryDescription">With Google Play services, your app can take advantage of the latest, Google-powered features such as Maps, Google+, and more, with automatic platform updates distributed as an APK through the Google Play store.</string>
+	<string name="library_GooglePlayServices_libraryWebsite">https://developer.android.com/google/play-services/index.html</string>
+	<string name="library_GooglePlayServices_licenseId">apache_2_0</string>
+	<string name="library_GooglePlayServices_isOpenSource">false</string>
+	<string name="library_GooglePlayServices_repositoryLink"></string>
+	<!-- Custom variables section -->
+	<string name="library_GooglePlayServices_owner">AOSP</string>
+	<string name="library_GooglePlayServices_year">2015</string>
+</resources> 

--- a/library/src/main/res/values/library_supportlibrary_strings.xml
+++ b/library/src/main/res/values/library_supportlibrary_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="define_int_SupportLibrary">year;owner</string>
+	<string name="library_SupportLibrary_author">AOSP</string>
+	<string name="library_SupportLibrary_authorWebsite">https://source.android.com/</string>
+	<string name="library_SupportLibrary_classPath">com.android.support.v4</string>
+	<string name="library_SupportLibrary_libraryName">Support Library</string>
+	<string name="library_SupportLibrary_libraryDescription">This library includes support for application components, user interface features, accessibility, data handling, network connectivity, and programming utilities.</string>
+	<string name="library_SupportLibrary_libraryWebsite">https://developer.android.com/tools/support-library/features.html#v4</string>
+	<string name="library_SupportLibrary_licenseId">apache_2_0</string>
+	<string name="library_SupportLibrary_isOpenSource">false</string>
+	<string name="library_SupportLibrary_repositoryLink"></string>
+	<!-- Custom variables section -->
+	<string name="library_SupportLibrary_owner">AOSP</string>
+	<string name="library_SupportLibrary_year">2015</string>
+</resources> 


### PR DESCRIPTION
I'm including 2 changes: first, 5 new libraries. None are open source, so there is no direct way to get the authors to include these strings (especially since these are owned by Google, Twitter, and Facebook). Best guesses are made for a couple of these, as well, though all information should be accurate.

Second change is one to solve a problem I noted: I had left version numbers out of these 5 library's data, but other libraries had version number data. With RecyclerView and the ViewHolder pattern, as soon as an item is scrolled off-screen, it gets removed from memory. When you scroll back, those cards are re-built using the ViewHolder in memory, and thus you get version numbers from other libraries showing on the cards of libraries that don't have version data. Removing static from the ViewHolder should resolve that.