### PR TITLE
fixes using repositoryLink if libraryWebsite is not set

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/adapter/LibsRecyclerViewAdapter.java
@@ -254,7 +254,7 @@ public class LibsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
                 holder.libraryCreator.setOnLongClickListener(null);
             }
 
-            if (!TextUtils.isEmpty(library.getLibraryWebsite()) && !TextUtils.isEmpty(library.getRepositoryLink())) {
+            if (!TextUtils.isEmpty(library.getLibraryWebsite()) || !TextUtils.isEmpty(library.getRepositoryLink())) {
                 holder.libraryDescription.setOnTouchListener(rippleForegroundListener);
                 holder.libraryDescription.setOnClickListener(new View.OnClickListener() {
                     @Override


### PR DESCRIPTION
without the fix, this would not make sense:

library.getLibraryWebsite() != null ? library.getLibraryWebsite() : library.getRepositoryLink()


;-)