### PR TITLE
Update StyledDialogs library info

### DIFF
--- a/library/src/main/res/values/library_androidstyleddialogs_strings.xml
+++ b/library/src/main/res/values/library_androidstyleddialogs_strings.xml
@@ -2,17 +2,17 @@
 <resources>
 
     <string name="define_int_androidStyledDialogs">year;owner</string>
-    <string name="library_androidStyledDialogs_author">inmite</string>
-    <string name="library_androidStyledDialogs_authorWebsite">http://www.inmite.eu</string>
+    <string name="library_androidStyledDialogs_author">Avast</string>
+    <string name="library_androidStyledDialogs_authorWebsite">http://www.avast.com</string>
     <string name="library_androidStyledDialogs_libraryName">StyledDialogs</string>
-    <string name="library_androidStyledDialogs_libraryDescription">This library makes styling and using dialogs a piece of cake.</string>
-    <string name="library_androidStyledDialogs_libraryVersion">1.1.2</string>
-    <string name="library_androidStyledDialogs_libraryWebsite">https://github.com/inmite/android-styled-dialogs</string>
+    <string name="library_androidStyledDialogs_libraryDescription">Backport of material dialogs with easy-to-use API based on DialogFragment. This library makes styling and using dialogs a piece of cake.</string>
+    <string name="library_androidStyledDialogs_libraryVersion">2.3.3</string>
+    <string name="library_androidStyledDialogs_libraryWebsite">https://github.com/avast/android-styled-dialogs</string>
     <string name="library_androidStyledDialogs_licenseId">apache_2_0</string>
     <string name="library_androidStyledDialogs_isOpenSource">true</string>
-    <string name="library_androidStyledDialogs_repositoryLink">https://github.com/inmite/android-styled-dialogs</string>
-    <string name="library_androidStyledDialogs_classPath">eu.inmite.android.lib.dialogs.BaseDialogBuilder</string>
+    <string name="library_androidStyledDialogs_repositoryLink">https://github.com/avast/android-styled-dialogs</string>
+    <string name="library_androidStyledDialogs_classPath">com.avast.android.dialogs.core.BaseDialogBuilder</string>
     <!-- Custom variables section -->
-    <string name="library_androidStyledDialogs_owner">inmite</string>
+    <string name="library_androidStyledDialogs_owner">Avast</string>
     <string name="library_androidStyledDialogs_year">2014</string>
 </resources>


### PR DESCRIPTION
The information about StyledDialog were very outdated.
The library has been updated for material design.
And most importantly StyledDialogs were moved 
from Inmite to Avast in 2014 (company acquisition).
Some things were changed due to the transfer:
owner, repository, package names, groupId, artifactId.