### PR TITLE
Remove duplicated entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ android:
   licenses:
     - '.+'
 
-jdk:
-  - oraclejdk8
-
 script:
     - ./gradlew clean assemble --stacktrace
 


### PR DESCRIPTION
.travis.yml defined the jdk two times, this has now been fixed.