### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 ext {
     compileSdkVersion = 24
     buildToolsVersion = "24.0.1"
-    supportLibVersion = "24.2.0"
+    supportLibVersion = "24.2.1"
 }
 
 allprojects {


### PR DESCRIPTION
Google broke the dependency on support libraries `24.2.0`, so updating to the latest will fix it. No other changes needed.