### PR TITLE
Fixes failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-24.0.0
+    - build-tools-24.0.1
 
     # The SDK version used to compile your project
     - android-24


### PR DESCRIPTION
Updates entry for `build-tools` 24.0.1 as travis is crashing because of missing build-tools