### PR TITLE
made the description styleable

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.java
@@ -286,17 +286,17 @@ public class HeaderItem extends AbstractItem<HeaderItem, HeaderItem.ViewHolder> 
             //get the about this app views
             aboutIcon = (ImageView) headerView.findViewById(R.id.aboutIcon);
             aboutAppName = (TextView) headerView.findViewById(R.id.aboutName);
-            aboutAppName.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_title_openSource, R.color.about_libraries_title_openSource));
+            aboutAppName.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_title_description, R.color.about_libraries_title_description));
             aboutSpecialContainer = headerView.findViewById(R.id.aboutSpecialContainer);
             aboutSpecial1 = (Button) headerView.findViewById(R.id.aboutSpecial1);
             aboutSpecial2 = (Button) headerView.findViewById(R.id.aboutSpecial2);
             aboutSpecial3 = (Button) headerView.findViewById(R.id.aboutSpecial3);
             aboutVersion = (TextView) headerView.findViewById(R.id.aboutVersion);
-            aboutVersion.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_openSource, R.color.about_libraries_text_openSource));
+            aboutVersion.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_description, R.color.about_libraries_text_description));
             aboutDivider = headerView.findViewById(R.id.aboutDivider);
-            aboutDivider.setBackgroundColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_dividerDark_openSource, R.color.about_libraries_dividerDark_openSource));
+            aboutDivider.setBackgroundColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_dividerDark_description, R.color.about_libraries_dividerDark_description));
             aboutAppDescription = (TextView) headerView.findViewById(R.id.aboutDescription);
-            aboutAppDescription.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_openSource, R.color.about_libraries_text_openSource));
+            aboutAppDescription.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_description, R.color.about_libraries_text_description));
         }
     }
 }

--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.java
@@ -294,7 +294,7 @@ public class HeaderItem extends AbstractItem<HeaderItem, HeaderItem.ViewHolder> 
             aboutVersion = (TextView) headerView.findViewById(R.id.aboutVersion);
             aboutVersion.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_description, R.color.about_libraries_text_description));
             aboutDivider = headerView.findViewById(R.id.aboutDivider);
-            aboutDivider.setBackgroundColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_dividerDark_description, R.color.about_libraries_dividerDark_description));
+            aboutDivider.setBackgroundColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_divider_description, R.color.about_libraries_divider_description));
             aboutAppDescription = (TextView) headerView.findViewById(R.id.aboutDescription);
             aboutAppDescription.setTextColor(UIUtils.getThemeColorFromAttrOrRes(headerView.getContext(), R.attr.about_libraries_text_description, R.color.about_libraries_text_description));
         }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -4,6 +4,9 @@
     <declare-styleable name="AboutLibraries">
         <attr name="about_libraries_window_background" format="color|reference"/>
         <attr name="about_libraries_card" format="color|reference"/>
+        <attr name="about_libraries_title_description" format="color|reference"/>
+        <attr name="about_libraries_text_description" format="color|reference"/>
+        <attr name="about_libraries_dividerDark_description" format="color|reference"/>
         <attr name="about_libraries_title_openSource" format="color|reference"/>
         <attr name="about_libraries_text_openSource" format="color|reference"/>
         <attr name="about_libraries_special_button_openSource" format="color|reference"/>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,7 +6,7 @@
         <attr name="about_libraries_card" format="color|reference"/>
         <attr name="about_libraries_title_description" format="color|reference"/>
         <attr name="about_libraries_text_description" format="color|reference"/>
-        <attr name="about_libraries_dividerDark_description" format="color|reference"/>
+        <attr name="about_libraries_divider_description" format="color|reference"/>
         <attr name="about_libraries_title_openSource" format="color|reference"/>
         <attr name="about_libraries_text_openSource" format="color|reference"/>
         <attr name="about_libraries_special_button_openSource" format="color|reference"/>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -28,4 +28,9 @@
     <color name="about_libraries_special_button_openSource_dark">#ffffffff</color>
     <color name="about_libraries_dividerDark_openSource_dark">#303030</color>
     <color name="about_libraries_dividerLight_openSource_dark">#303030</color>
+
+    <!-- Reuse colors for backwards compatibility -->
+    <color name="about_libraries_title_description">@color/about_libraries_title_openSource</color>
+    <color name="about_libraries_text_description">@color/about_libraries_text_openSource</color>
+    <color name="about_libraries_dividerDark_description">@color/about_libraries_dividerDark_openSource</color>
 </resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -32,5 +32,5 @@
     <!-- Reuse colors for backwards compatibility -->
     <color name="about_libraries_title_description">@color/about_libraries_title_openSource</color>
     <color name="about_libraries_text_description">@color/about_libraries_text_openSource</color>
-    <color name="about_libraries_dividerDark_description">@color/about_libraries_dividerDark_openSource</color>
+    <color name="about_libraries_divider_description">@color/about_libraries_dividerDark_openSource</color>
 </resources>


### PR DESCRIPTION
Added the possiblity to change the text color of the description. This fixes my problem mentioned in #266 while maintaining backwards compatibility.

In the long term, `about_libraries_dividerDark_openSource` and `about_libraries_dividerLight_openSource` may be renamed as well, to reflect their usage better. One is used exclusively in HeaderItem the other one in LibraryItem. Maybe they should be renamed to `about_libraries_divider_openSource` and `about_libraries_divider_description`.