### PR TITLE
Update dependencies and remove app_name from library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ android:
   components:
     # Uncomment the lines below if you want to
     # use the latest revision of Android SDK Tools
-    # - platform-tools
     - tools
+    - platform-tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.2
+    - build-tools-26.0.1
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,27 +45,25 @@ android {
 }
 
 dependencies {
-    compile project(':library')
+    implementation project(':library')
 
     // used to base on some backwards compatible themes
     // contains util classes to support various android versions, and clean up code
     // comes with the awesome "Holder"-Pattern
     // https://github.com/mikepenz/Materialize
-    compile 'com.mikepenz:materialize:1.0.3@aar'
+    implementation 'com.mikepenz:materialize:1.0.3@aar'
 
     //used to generate the drawer on the left
     //https://github.com/mikepenz/MaterialDrawer
-    compile('com.mikepenz:materialdrawer:5.9.5@aar') {
+    implementation('com.mikepenz:materialdrawer:5.9.5@aar') {
         transitive = true
-        exclude module: "fastadapter"
-        exclude module: "iconics-core"
     }
 
     //used to provide different itemAnimators for the RecyclerView
     //https://github.com/mikepenz/ItemAnimators
-    compile 'com.mikepenz:itemanimators:1.0.0@aar'
+    implementation 'com.mikepenz:itemanimators:1.0.0@aar'
 
     //used to display the icons in the drawer
     //https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:material-design-iconic-typeface:2.2.0.3@aar'
+    implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.3@aar'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 //wrap with try and catch so the build is working even if the signing stuff is missing
 try {
     apply from: '../../../signing.gradle'
-} catch (ex) {
+} catch (ignored) {
 }
 
 
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 597
         versionName '5.9.7'
     }
@@ -23,14 +23,14 @@ android {
             versionNameSuffix "-DEBUG"
             try {
                 signingConfig signingConfigs.debug
-            } catch (ex) {
+            } catch (ignored) {
             }
             minifyEnabled false
         }
         release {
             try {
                 signingConfig signingConfigs.release
-            } catch (ex) {
+            } catch (ignored) {
             }
             zipAlignEnabled true
             minifyEnabled false
@@ -55,7 +55,7 @@ dependencies {
 
     //used to generate the drawer on the left
     //https://github.com/mikepenz/MaterialDrawer
-    compile('com.mikepenz:materialdrawer:5.9.4@aar') {
+    compile('com.mikepenz:materialdrawer:5.9.5@aar') {
         transitive = true
         exclude module: "fastadapter"
         exclude module: "iconics-core"
@@ -67,5 +67,5 @@ dependencies {
 
     //used to display the icons in the drawer
     //https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:material-design-iconic-typeface:2.2.0.1@aar'
+    compile 'com.mikepenz:material-design-iconic-typeface:2.2.0.3@aar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ buildscript {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = "25.0.2"
-    supportLibVersion = "25.4.0"
+    compileSdkVersion = 26
+    buildToolsVersion = "26.0.1"
+    supportLibVersion = "26.0.0"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha6'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 597
         versionName '5.9.7'
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     // used to provide out of the box icon font support. simplifies development,
     // and provides scalable icons. the core is very very light
     // https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:iconics-core:2.9.0@aar'
+    compile 'com.mikepenz:iconics-core:2.9.1@aar'
 
     // used to fill the RecyclerView with the items
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    compile 'com.mikepenz:fastadapter:2.6.2@aar'
+    compile 'com.mikepenz:fastadapter:2.6.3@aar'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,17 +29,17 @@ apply from: 'gradle-mvn-push.gradle'
 apply from: 'gradle-jcenter-push.gradle'
 
 dependencies {
-    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:cardview-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:cardview-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
 
     // used to provide out of the box icon font support. simplifies development,
     // and provides scalable icons. the core is very very light
     // https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:iconics-core:2.9.1@aar'
+    implementation 'com.mikepenz:iconics-core:2.9.1@aar'
 
     // used to fill the RecyclerView with the items
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    compile 'com.mikepenz:fastadapter:2.6.3@aar'
+    implementation 'com.mikepenz:fastadapter:2.6.3@aar'
 }

--- a/library/src/main/res/values/library_rxandroid_strings.xml
+++ b/library/src/main/res/values/library_rxandroid_strings.xml
@@ -9,7 +9,7 @@
 	<string name="library_rxandroid_libraryName">RxAndroid</string>
 	<string name="library_rxandroid_libraryDescription"><![CDATA[Android specific bindings for <b>RxJava</b>.<br /><br />This module adds the minimum classes to RxJava that make writing reactive components in Android applications easy and hassle-free. More specifically, it provides a Scheduler that schedules on the main UI thread or any given Handler.]]></string>
 	<string name="library_rxandroid_libraryWebsite">https://github.com/ReactiveX/RxAndroid</string>
-	<string name="library_rxandroid_libraryVersion">1.2.1</string>
+	<string name="library_rxandroid_libraryVersion">2.0.1</string>
 	<!-- OpenSource section -->
 	<string name="library_rxandroid_isOpenSource">true</string>
 	<string name="library_rxandroid_repositoryLink">https://github.com/ReactiveX/RxAndroid</string>

--- a/library/src/main/res/values/library_rxbinding_strings.xml
+++ b/library/src/main/res/values/library_rxbinding_strings.xml
@@ -4,7 +4,7 @@
     <string name="library_RxBinding_author">Jake Wharton</string>
     <string name="library_RxBinding_libraryName">RxBinding</string>
     <string name="library_RxBinding_libraryDescription">RxJava binding APIs for Android\'s UI widgets.</string>
-    <string name="library_RxBinding_libraryVersion">0.2.0</string>
+    <string name="library_RxBinding_libraryVersion">2.0.0</string>
     <string name="library_RxBinding_libraryWebsite">https://github.com/JakeWharton/RxBinding</string>
     <string name="library_RxBinding_licenseId">apache_2_0</string>
     <string name="library_RxBinding_isOpenSource">true</string>

--- a/library/src/main/res/values/library_rxjava_strings.xml
+++ b/library/src/main/res/values/library_rxjava_strings.xml
@@ -9,12 +9,12 @@
 	<string name="library_rxjava_libraryName">RxJava</string>
 	<string name="library_rxjava_libraryDescription"><![CDATA[<b>RxJava</b> is a Java VM implementation of Reactive Extensions: a library for composing asynchronous and event-based programs by using observable sequences.<br /><br />It extends the observer pattern to support sequences of data/events and adds operators that allow you to compose sequences together declaratively while abstracting away concerns about things like low-level threading, synchronization, thread-safety and concurrent data structures.]]></string>
 	<string name="library_rxjava_libraryWebsite">https://github.com/ReactiveX/RxJava</string>
-	<string name="library_rxjava_libraryVersion">1.1.6</string>
+	<string name="library_rxjava_libraryVersion">2.1.2</string>
 	<!-- OpenSource section -->
 	<string name="library_rxjava_isOpenSource">true</string>
 	<string name="library_rxjava_repositoryLink">https://github.com/ReactiveX/RxJava</string>
 	<!-- ClassPath for autoDetect section -->
-	<string name="library_rxjava_classPath">rx.Observable</string>
+	<string name="library_rxjava_classPath">io.reactivex</string>
 	<!-- License section -->
 	<string name="library_rxjava_licenseId">apache_2_0</string>
 	<!-- Custom variables section -->

--- a/library/src/main/res/values/library_rxkotlin_strings.xml
+++ b/library/src/main/res/values/library_rxkotlin_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+	<string name="define_int_rxkotlin">year;owner</string>
+	<!-- Author section -->
+	<string name="library_rxkotlin_author">ReactiveX</string>
+	<string name="library_rxkotlin_authorWebsite">http://reactivex.io/</string>
+	<!-- Library section -->
+	<string name="library_rxkotlin_libraryName">RxKotlin</string>
+	<string name="library_rxkotlin_libraryDescription"><![CDATA[<b>RxKotlin</b> is a lightweight library that adds convenient extension functions to RxJava.]]></string>
+	<string name="library_rxkotlin_libraryWebsite">https://github.com/ReactiveX/RxKotlin</string>
+	<string name="library_rxkotlin_libraryVersion">2.1.0</string>
+	<!-- OpenSource section -->
+	<string name="library_rxkotlin_isOpenSource">true</string>
+	<string name="library_rxkotlin_repositoryLink">https://github.com/ReactiveX/RxKotlin</string>
+	<!-- ClassPath for autoDetect section -->
+	<string name="library_rxkotlin_classPath">io.reactivex.kotlin</string>
+	<!-- License section -->
+	<string name="library_rxkotlin_licenseId">apache_2_0</string>
+	<!-- Custom variables section -->
+    <string name="library_rxkotlin_owner">RxKotlin Contributors</string>
+    <string name="library_rxkotlin_year">2016-present</string>
+</resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string name="app_name">AboutLibraries</string>
     <string name="version">Version</string>
 </resources>


### PR DESCRIPTION
The main point of this commit was to remove the `app_name` string from the library module, as it isn't used and it leaks to other dependencies. 

Since I imported this into Android Studio, I decided to update other components as well.
* Update gradle wrapper to latest rc and tool to latest alpha
* Update all of your libraries
* Update build tools and sdk to 26; the build tool is out of beta now
* Go for implementation rather than compile. This avoids leaking interfaces to app projects and reduces build time. You may want to test this out to ensure that there are no issues with maven.

If you don't want to update dependencies, you may cherry pick the app_name deletion.

Another thing I wasn't sure if you wanted was that you can add the following to your build gradle:

```gradle
android {
    defaultConfig {
        resValue "string", "library_AboutLibrary_libraryVersion", project.VERSION_NAME
    }
}
```

to avoid having to manually change the version string when you update your library.
You can keep the `VERSION_NAME` under a gradle or property file so you only need to change it once.