### PR TITLE
Use Gradle's `${rootProject.ext.supportLibVersion}` as Support lib version

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,6 +10,8 @@ android {
         targetSdkVersion 27
         versionCode 6010
         versionName '6.0.1'
+        
+        resValue "string", "ext_support_lib_version", "${rootProject.ext.supportLibVersion}"
     }
 
     buildTypes {

--- a/library/src/main/res/values/library_appcompat_v7_strings.xml
+++ b/library/src/main/res/values/library_appcompat_v7_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_appcompat_v7_libraryName">Support AppCompat v7</string>
     <string name="library_appcompat_v7_libraryDescription">This library adds support for the Action Bar user interface design pattern.</string>
     <string name="library_appcompat_v7_libraryWebsite">https://developer.android.com/topic/libraries/support-library/packages.html</string>
-    <string name="library_appcompat_v7_libraryVersion">23.2.1</string>
+    <string name="library_appcompat_v7_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_appcompat_v7_isOpenSource">true</string>
     <string name="library_appcompat_v7_repositoryLink"></string>

--- a/library/src/main/res/values/library_design_strings.xml
+++ b/library/src/main/res/values/library_design_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_design_libraryName">Support Design</string>
     <string name="library_design_libraryDescription">The Design package provides APIs to support adding material design components and patterns to your apps.  The Design Support library adds support for various material design components and patterns for app developers to build upon, such as navigation drawers, floating action buttons (FAB), snackbars, and tabs.</string>
     <string name="library_design_libraryWebsite">https://developer.android.com/reference/android/support/design/widget/package-summary.html</string>
-    <string name="library_design_libraryVersion">23.2.1</string>
+    <string name="library_design_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_design_isOpenSource">true</string>
     <string name="library_design_repositoryLink"></string>
@@ -21,3 +21,4 @@
     <string name="library_design_owner">The Android Open Source Project</string>
     <string name="library_design_year">2011</string>
 </resources>
+

--- a/library/src/main/res/values/library_recyclerview_v7_strings.xml
+++ b/library/src/main/res/values/library_recyclerview_v7_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_recyclerview_v7_libraryName">Support RecyclerView v7</string>
     <string name="library_recyclerview_v7_libraryDescription">The recyclerview library adds the RecyclerView class. This class provides support for the RecyclerView widget, a view for efficiently displaying large data sets by providing a limited window of data items.</string>
     <string name="library_recyclerview_v7_libraryWebsite">https://developer.android.com/reference/android/support/v7/widget/RecyclerView.html</string>
-    <string name="library_recyclerview_v7_libraryVersion">23.2.1</string>
+    <string name="library_recyclerview_v7_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_recyclerview_v7_isOpenSource">true</string>
     <string name="library_recyclerview_v7_repositoryLink"></string>

--- a/library/src/main/res/values/library_support_annotations_strings.xml
+++ b/library/src/main/res/values/library_support_annotations_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_support_annotations_libraryName">Support Annotations</string>
     <string name="library_support_annotations_libraryDescription">The Annotation package provides APIs to support adding annotation metadata to your apps.</string>
     <string name="library_support_annotations_libraryWebsite">https://developer.android.com/reference/android/support/annotation/package-summary.html</string>
-    <string name="library_support_annotations_libraryVersion">23.2.1</string>
+    <string name="library_support_annotations_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_support_annotations_isOpenSource">true</string>
     <string name="library_support_annotations_repositoryLink"></string>

--- a/library/src/main/res/values/library_support_cardview_strings.xml
+++ b/library/src/main/res/values/library_support_cardview_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_support_cardview_libraryName">CardView</string>
     <string name="library_support_cardview_libraryDescription">A FrameLayout with a rounded corner background and shadow.</string>
     <string name="library_support_cardview_libraryWebsite">https://developer.android.com/reference/android/support/v7/widget/CardView.html</string>
-    <string name="library_support_cardview_libraryVersion">23.2.1</string>
+    <string name="library_support_cardview_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_support_cardview_isOpenSource">true</string>
     <string name="library_support_cardview_repositoryLink"></string>

--- a/library/src/main/res/values/library_support_gridlayout_strings.xml
+++ b/library/src/main/res/values/library_support_gridlayout_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_support_gridlayout_libraryName">GridLayout</string>
     <string name="library_support_gridlayout_libraryDescription">A layout that places its children in a rectangular grid.  The grid is composed of a set of infinitely thin lines that separate the viewing area into cells.</string>
     <string name="library_support_gridlayout_libraryWebsite">https://developer.android.com/reference/android/widget/GridLayout.html</string>
-    <string name="library_support_gridlayout_libraryVersion">23.2.1</string>
+    <string name="library_support_gridlayout_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_support_gridlayout_isOpenSource">true</string>
     <string name="library_support_gridlayout_repositoryLink"></string>

--- a/library/src/main/res/values/library_support_multidex.xml
+++ b/library/src/main/res/values/library_support_multidex.xml
@@ -9,7 +9,7 @@
     <string name="library_multidex_libraryName">MultiDex</string>
     <string name="library_multidex_libraryDescription">MultiDex patches the application context class loader in order to load classes from more than one dex file.</string>
     <string name="library_multidex_libraryWebsite">https://developer.android.com/reference/android/support/multidex/MultiDex.html</string>
-    <string name="library_multidex_libraryVersion">23.2.1</string>
+    <string name="library_multidex_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_multidex_isOpenSource">true</string>
     <string name="library_multidex_repositoryLink"></string>

--- a/library/src/main/res/values/library_support_v4_strings.xml
+++ b/library/src/main/res/values/library_support_v4_strings.xml
@@ -9,7 +9,7 @@
     <string name="library_support_v4_libraryName">Support v4</string>
     <string name="library_support_v4_libraryDescription">This library is designed to be used with Android 1.6 (API level 4) and higher. It includes the largest set of APIs compared to the other libraries, including support for application components, user interface features, accessibility, data handling, network connectivity, and programming utilities.</string>
     <string name="library_support_v4_libraryWebsite">https://developer.android.com/tools/support-library/features.html#v4</string>
-    <string name="library_support_v4_libraryVersion">23.2.1</string>
+    <string name="library_support_v4_libraryVersion">@string/ext_support_lib_version</string>
     <!-- OpenSource section -->
     <string name="library_support_v4_isOpenSource">true</string>
     <string name="library_support_v4_repositoryLink"></string>


### PR DESCRIPTION
Today AboutLibraries has hardcoded Support libraries versions in its XMLs. From the last version of AboutLibraries the library's Gradle file use version of Support library from `${rootProject.ext.supportLibVersion}` so I extracted this variable into String resource and then I put it into these XMLs.

This will let the AboutLibraries to show the currently used version of Support and Design library instead of some old one.