### PR TITLE
Use api instead of compile

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,10 +39,10 @@ dependencies {
     // used to provide out of the box icon font support. simplifies development,
     // and provides scalable icons. the core is very very light
     // https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:iconics-core:3.0.2@aar'
+    api 'com.mikepenz:iconics-core:3.0.2@aar'
 
     // used to fill the RecyclerView with the items
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    compile 'com.mikepenz:fastadapter:3.2.4@aar'
+    api 'com.mikepenz:fastadapter:3.2.4@aar'
 }


### PR DESCRIPTION
Since compile is going to be removed at some point, `api` will take its place. It essentially will have the same effect here, so nothing to worry about. 