### PR TITLE
Add FLAG_ACTIVITY_NEW_TASK to intent before starting LibsActivity

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/LibsBuilder.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/LibsBuilder.java
@@ -580,6 +580,7 @@ public class LibsBuilder implements Serializable {
      */
     public void start(Context ctx) {
         Intent i = intent(ctx);
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         ctx.startActivity(i);
     }
 


### PR DESCRIPTION
Fix #383.

Add FLAG_ACTIVITY_NEW_TASK to intent so that the apps don't die
while starting LibsActivity on older Androids.