### PR TITLE
Change Context source in onCreateView method

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/LibsFragment.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/LibsFragment.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.app.Fragment;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,8 +26,8 @@ public class LibsFragment extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return libsFragmentCompat.onCreateView(container.getContext(), inflater, container, savedInstanceState, getArguments());
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return libsFragmentCompat.onCreateView(inflater.getContext(), inflater, container, savedInstanceState, getArguments());
     }
 
     @Override

--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.java
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.java
@@ -1,6 +1,7 @@
 package com.mikepenz.aboutlibraries.ui;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -22,8 +23,8 @@ public class LibsSupportFragment extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return libsFragmentCompat.onCreateView(container.getContext(), inflater, container, savedInstanceState, getArguments());
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return libsFragmentCompat.onCreateView(inflater.getContext(), inflater, container, savedInstanceState, getArguments());
     }
 
     @Override


### PR DESCRIPTION
Parameter container is nullable and geting Context source from it can provide NullPointerException.

Example: Screen rotation. In my app I have master-detail landscape layout (list on the left and fragment on the right) and only list in portrait layout. When we are showing LibsSupportFragment in right fragment container and then we rotate device to portrait we get NPE, because container is null