### PR TITLE
Fix centering of list item in parent view

### DIFF
--- a/library/src/main/res/layout/fragment_opensource.xml
+++ b/library/src/main/res/layout/fragment_opensource.xml
@@ -8,5 +8,5 @@
     android:paddingTop="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:scrollbarStyle="outsideInset"
+    android:scrollbarStyle="outsideOverlay"
     android:scrollbars="vertical" />


### PR DESCRIPTION
Change property of scroll bar visibility in order to don't affect horizontal centering of list items.

Before (without and with scroll bar visible)

![device-2019-07-02-121137](https://user-images.githubusercontent.com/1997543/60505070-3b5cbd00-9cc3-11e9-9db9-641185badfd1.png)
![device-2019-07-02-121144](https://user-images.githubusercontent.com/1997543/60505081-3ef04400-9cc3-11e9-991e-1401c4558c66.png)


After (without and with scroll bar visible)

![device-2019-07-02-121050](https://user-images.githubusercontent.com/1997543/60505106-46afe880-9cc3-11e9-9327-5332dc9d2b53.png)
![device-2019-07-02-121108](https://user-images.githubusercontent.com/1997543/60505109-4a436f80-9cc3-11e9-804d-270e45bd291d.png)

