### PR TITLE
Don't ignore aboutLibraries_description_text and name

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/LibsBuilder.kt
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/LibsBuilder.kt
@@ -39,9 +39,9 @@ class LibsBuilder : Serializable {
 
     var aboutShowIcon: Boolean = true
     var aboutVersionString: String = ""
-    var aboutAppName: String = ""
+    var aboutAppName: String? = null
     var aboutShowVersion: Boolean = true
-    var aboutDescription: String = ""
+    var aboutDescription: String? = null
     var aboutShowVersionName: Boolean = true
     var aboutShowVersionCode: Boolean = true
 

--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.kt
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/HeaderItem.kt
@@ -93,7 +93,7 @@ class HeaderItem(var libsBuilder: LibsBuilder) : AbstractItem<HeaderItem.ViewHol
         }
 
         //Set the description or hide it
-        if (libsBuilder.aboutAppName.isNotEmpty()) {
+        if (TextUtils.isEmpty(libsBuilder.aboutAppName)) {
             holder.aboutAppName.text = libsBuilder.aboutAppName
         } else {
             holder.aboutAppName.visibility = View.GONE
@@ -200,7 +200,7 @@ class HeaderItem(var libsBuilder: LibsBuilder) : AbstractItem<HeaderItem.ViewHol
         }
 
         //Set the description or hide it
-        if (libsBuilder.aboutDescription.isNotEmpty()) {
+        if (TextUtils.isEmpty(libsBuilder.aboutDescription)) {
             holder.aboutAppDescription.text = Html.fromHtml(libsBuilder.aboutDescription)
             Iconics.Builder().ctx(ctx).on(holder.aboutAppDescription).build()
             holder.aboutAppDescription.movementMethod = MovementCheck.instance


### PR DESCRIPTION
Before this change, the value of `aboutLibraries_description_text` and `aboutLibraries_description_name` were ignored. This fix  that.