### PR TITLE
Improve handling of missing version in the artifact's POM

### DIFF
--- a/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
+++ b/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
@@ -259,23 +259,27 @@ class AboutLibrariesProcessor {
             return
         }
 
-        libraries.add(
-                new Library(
-                        uniqueId,
-                        "${groupId}:${artifactPom.artifactId}:${artifactPom.version}",
-                        author,
-                        authorWebsite,
-                        libraryName,
-                        libraryDescription,
-                        libraryVersion,
-                        libraryWebsite,
-                        licenseId,
-                        isOpenSource,
-                        repositoryLink,
-                        libraryOwner,
-                        licenseYear
-                )
+        def library = new Library(
+                uniqueId,
+                // TODO: Why was this used instead of component.displayName?
+                //"${groupId}:${artifactPom.artifactId}:${artifactPom.version}",
+                // Alternate
+                //"${groupId}:${artifactPom.artifactId}:${libraryVersion}",
+                component.displayName,
+                author,
+                authorWebsite,
+                libraryName,
+                libraryDescription,
+                libraryVersion,
+                libraryWebsite,
+                licenseId,
+                isOpenSource,
+                repositoryLink,
+                libraryOwner,
+                licenseYear
         )
+        LOGGER.debug("Adding library: {}", library);
+        libraries.add(library);
     }
 
     /**


### PR DESCRIPTION
Fixes two issues related to missing version indicators in the pom itself:
1. If `artifactPom.version` is missing, use `artifactPom.parent.version` (the version sub-element of the parent element of the artifactPom) before attempting to retrieve the artifact's parent pom.
2. When creating the `Library` instance, use the original `component.displayName` instead of attempting to reconstruct it.

Also added a logger and several debug messages.