### PR TITLE
Fix card background color

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/LibraryItem.kt
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/LibraryItem.kt
@@ -237,7 +237,7 @@ class LibraryItem(private val library: Library, private val libsBuilder: LibsBui
         init {
             val ctx = itemView.context
             ctx.resolveStyledValue {
-                card.setCardBackgroundColor(it.getColor(R.styleable.AboutLibraries_aboutLibrariesWindowBackground, ctx.getThemeColor(R.attr.aboutLibrariesWindowBackground, ctx.getSupportColor(R.color.about_libraries_card))))
+                card.setCardBackgroundColor(it.getColor(R.styleable.AboutLibraries_aboutLibrariesCardBackground, ctx.getThemeColor(R.attr.aboutLibrariesCardBackground, ctx.getSupportColor(R.color.about_libraries_card))))
                 libraryName.setTextColor(it.getColorStateList(R.styleable.AboutLibraries_aboutLibrariesOpenSourceTitle))
                 libraryCreator.setTextColor(it.getColorStateList(R.styleable.AboutLibraries_aboutLibrariesOpenSourceText))
                 libraryDescriptionDivider.setBackgroundColor(it.getColor(R.styleable.AboutLibraries_aboutLibrariesOpenSourceDivider, ctx.getThemeColor(R.attr.aboutLibrariesOpenSourceDivider, ctx.getSupportColor(R.color.about_libraries_dividerLight_openSource))))

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
     <style name="AboutLibrariesStyle" parent="">
         <!-- AboutLibraries specific values -->
         <item name="aboutLibrariesWindowBackground">?android:colorBackground</item>
-        <item name="aboutLibrariesCardBackground">?cardBackgroundColor</item>
+        <item name="aboutLibrariesCardBackground">?attr/colorSurface</item>
         <item name="aboutLibrariesDescriptionTitle">?android:textColorPrimary</item>
         <item name="aboutLibrariesDescriptionText">?android:textColorSecondary</item>
         <item name="aboutLibrariesDescriptionDivider">@color/opensource_divider</item>


### PR DESCRIPTION
It looks like the card background color was incorrectly set to be the window background color.

After making that change, the `cardBackgroundColor` attribute failed to be resolved but I'm not sure why:
```
2020-04-11 02:48:55.338 17272-17272/com.mikepenz.aboutlibraries.sample.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mikepenz.aboutlibraries.sample.debug, PID: 17272
    java.lang.UnsupportedOperationException: Failed to resolve attribute at index 0: TypedValue{t=0x2/d=0x7f03007e a=10}
        at android.content.res.TypedArray.getColor(TypedArray.java:527)
        at com.mikepenz.aboutlibraries.ui.item.LibraryItem$ViewHolder$1.invoke(LibraryItem.kt:240)
```

Instead of using that attribute, I've changed it to be `colorSurface`, which is the default color of [Material cards](https://material.io/develop/android/components/cards/).