### PR TITLE
[...] Update library dependencies to the latest stable versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
 
     // used only tho showcase multi flavor support
-    stagingImplementation("com.squareup.okhttp3:okhttp:4.4.0")
+    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.0")
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ buildscript {
                 recyclerview    : '1.1.0',
                 material        : '1.2.1',
                 kotlin          : "1.4.10",
-                constraintLayout: '2.0.1',
+                constraintLayout: '2.0.2',
                 iconics         : "5.0.3",
-                detekt          : '1.12.0',
-                fastadapter     : "5.2.3",
-                materialdrawer  : "8.1.5",
+                detekt          : '1.14.1',
+                fastadapter     : "5.2.4",
+                materialdrawer  : "8.1.6",
                 coreKtx         : "1.3.2"
         ]
     }
@@ -37,7 +37,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"


### PR DESCRIPTION
- update to constraintlayout 2.0.2
- update to detekt 1.14.1
- update to fastadapter 5.2.4
- update to materialdrawer 8.1.6
- use latest gradle build tools 4.0.2
- update sample to okhttp 4.9.0