### PR TITLE
Compliance export

### DIFF
--- a/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.groovy
+++ b/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.groovy
@@ -1,0 +1,148 @@
+package com.mikepenz.aboutlibraries.plugin
+
+import com.mikepenz.aboutlibraries.plugin.mapping.License
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+public class AboutLibrariesExportComplianceTask extends DefaultTask {
+
+    private String variant = null
+    private Set<License> neededLicenses = new HashSet<License>()
+    private Set<String> librariesWithoutLicenses = new HashSet<String>()
+    private HashMap<String, HashSet<String>> unknownLicenses = new HashMap<String, HashSet<String>>()
+
+    public void setVariant(String variant) {
+        this.variant = variant
+    }
+
+    String getVariant() {
+        return variant
+    }
+
+    Set<License> getNeededLicenses() {
+        return neededLicenses
+    }
+
+    Set<String> getLibrariesWithoutLicenses() {
+        return librariesWithoutLicenses
+    }
+
+    HashMap<String, HashSet<String>> getUnknownLicenses() {
+        return unknownLicenses
+    }
+
+    def gatherDependencies(def project) {
+        final def exportPath = project.getProperty("exportPath")
+        final def artifactGroups = project.hasProperty("artifactGroups") ? project.getProperty("artifactGroups") : ""
+
+        if (exportPath == null) {
+            throw new IllegalArgumentException("Please specify `exportPath` via the gradle CLI (-PexportPath=...)")
+        }
+
+        final def libraries = new AboutLibrariesProcessor().gatherDependencies(project, variant)
+
+        if (variant != null) {
+            println ""
+            println ""
+            println "Variant: ${variant}"
+        }
+
+        final def groups = artifactGroups?.split(";")
+        final def exportTargetFolder = new File(exportPath)
+        exportTargetFolder.mkdirs()
+
+        final def exportCsv = new File(exportTargetFolder, "export.csv")
+        exportCsv.delete()
+        final def exportTxt = new File(exportTargetFolder, "export.txt")
+        exportTxt.delete()
+
+        final def dependenciesFolder = new File(exportTargetFolder, "dependencies")
+        dependenciesFolder.deleteDir()
+
+        def ungroupedKey = "zzzzz_ungrouped"
+        def groupSorted = libraries.groupBy {
+            for (final group in groups) {
+                if (it.artifactId.startsWith(group)) {
+                    return group
+                }
+            }
+            return ungroupedKey
+        }
+
+        exportTxt.append("LIBRARIES:\n")
+
+        for (entry in groupSorted) {
+            def ungrouped = entry.key == ungroupedKey
+            def group = ungrouped ? "ungrouped" : entry.key
+
+            exportCsv.append("${group};;;\n")
+            exportTxt.append("${group}\n")
+
+            for (final library in entry.value) {
+                library.licenseIds.each { licenseId ->
+                    try {
+                        neededLicenses.add(License.valueOf(licenseId))
+                    } catch (Exception ex) {
+                        if (licenseId != null && licenseId != "") {
+                            HashSet<String> libsWithMissing = unknownLicenses.getOrDefault(licenseId, new HashSet<String>())
+                            libsWithMissing.add(library.artifactId)
+                            unknownLicenses.put(licenseId, libsWithMissing)
+                        } else {
+                            librariesWithoutLicenses.add(library.artifactId)
+                        }
+                    }
+                }
+
+                exportCsv.append("${library.libraryName};${library.artifactId};${library.licenseIds};${library.libraryWebsite ?: library.authorWebsite}\n")
+                exportTxt.append("${library.libraryName};${library.artifactId};${library.licenseIds}\n")
+
+                def targetFolder = "${library.artifactId}"
+                if (!ungrouped) {
+                    targetFolder = "${group}/${library.artifactId}"
+                }
+
+                def libraryTargetFolder = new File(dependenciesFolder, targetFolder)
+                libraryTargetFolder.mkdirs()
+
+                try {
+                    def source = library.artifactFolder.toPath()
+                    Files.walk(source).forEach { final s ->
+                        final def targetPath = libraryTargetFolder.toPath()
+                        final def fn = s.fileName.toString()
+                        if (!Files.isDirectory(s) && (fn.endsWith(".aar") || fn.endsWith(".jar") || fn.endsWith(".pom")) && !fn.endsWith("-javadoc.jar")) {
+                            Files.copy(s, targetPath.resolve(fn), StandardCopyOption.REPLACE_EXISTING)
+                        }
+                    }
+                } catch (Exception ex) {
+                    ex.printStackTrace()
+                }
+            }
+        }
+
+        exportTxt.append("\n\nLICENSES:\n")
+        for (final license in neededLicenses) {
+            exportTxt.append("${license.id};${license.fullName};${license.url}\n")
+        }
+
+        exportTxt.append("\n\nARTIFACTS WITHOUT LICENSE:\n")
+        for (final license in librariesWithoutLicenses) {
+            exportTxt.append("${license}\n")
+        }
+
+        exportTxt.append("\n\nUNKNOWN LICENSES:\n")
+        for (final entry in unknownLicenses) {
+            exportTxt.append("${entry.key}\n")
+            exportTxt.append("-- ${entry.value}\n")
+        }
+
+
+    }
+
+    @TaskAction
+    public void action() throws IOException {
+        gatherDependencies(project)
+    }
+}

--- a/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.groovy
+++ b/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.groovy
@@ -87,5 +87,11 @@ class AboutLibrariesPlugin implements Plugin<Project> {
         exportTaskId.description = "Writes all libraries and their license in CSV format to the CLI"
         exportTaskId.group = 'Help'
         exportTaskId.setVariant(variant.name)
+
+        // task to output libraries, their license in CSV format and source to a given location
+        AboutLibrariesExportComplianceTask exportComplianceTaskId = project.tasks.create("exportComplianceLibraries${variant.name.capitalize()}", AboutLibrariesExportComplianceTask)
+        exportComplianceTaskId.description = "Writes all libraries with their source and their license in CSV format to the configured directory"
+        exportComplianceTaskId.group = 'Help'
+        exportComplianceTaskId.setVariant(variant.name)
     }
 }

--- a/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
+++ b/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
@@ -33,13 +33,16 @@ class AboutLibrariesProcessor {
     List<String> customExclusionList = new ArrayList<String>()
 
     def collectMappingDetails(target, resourceName) {
-        def customMappingText = getClass().getResource("/static/${resourceName}").getText('UTF-8')
-        customMappingText.eachLine {
-            if (target instanceof Map) {
-                def splitMapping = it.split(':')
-                target.put(splitMapping[0], splitMapping[1])
-            } else if (target instanceof List) {
-                target.add(it)
+        def customMappingRef = getClass().getResource("/static/${resourceName}")
+        if (customMappingRef != null) {
+            def customMappingText = customMappingRef.getText('UTF-8')
+            customMappingText.eachLine {
+                if (target instanceof Map) {
+                    def splitMapping = it.split(':')
+                    target.put(splitMapping[0], splitMapping[1])
+                } else if (target instanceof List) {
+                    target.add(it)
+                }
             }
         }
 

--- a/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
+++ b/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesProcessor.groovy
@@ -293,7 +293,8 @@ class AboutLibrariesProcessor {
                 isOpenSource,
                 repositoryLink,
                 libraryOwner,
-                licenseYear
+                licenseYear,
+                artifactFile?.getParentFile()?.getParentFile() // artifactFile references the pom directly
         )
         LOGGER.debug("Adding library: {}", library)
         libraries.add(library)

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/Library.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/Library.kt
@@ -1,5 +1,7 @@
 package com.mikepenz.aboutlibraries.plugin.mapping
 
+import java.io.File
+
 /**
  * Library class describing a library and its information
  */
@@ -16,5 +18,6 @@ data class Library(
         val isOpenSource: Boolean,
         val repositoryLink: String?,
         val libraryOwner: String?,
-        val licenseYear: String?
+        val licenseYear: String?,
+        val artifactFolder: File? = null
 )


### PR DESCRIPTION
- add a new export task which is able to export dependencies in a form which may be helpful for compliance checks
  - include source of dependencies
  - libraries and licenses in csv format
  - possibility to group together specific groups (e.g. androidx)

```bash
./gradlew app:exportComplianceLibrariesRelease -PexportPath=export -PartifactGroups=org.jetbrains;androidx
```