### PR TITLE
Enhance custom license mapping | Fallback to display license id

### DIFF
--- a/config/custom_author_mappings.prop
+++ b/config/custom_author_mappings.prop
@@ -1,0 +1,1 @@
+com_squareup_okio__okio:Square, Inc

--- a/config/custom_enchant_mapping.prop
+++ b/config/custom_enchant_mapping.prop
@@ -1,0 +1,2 @@
+com_squareup_okhttp3__okhttp:okhttp
+com_squareup_okhttp__okhttp:okhttp

--- a/config/custom_license_mappings.prop
+++ b/config/custom_license_mappings.prop
@@ -1,0 +1,1 @@
+com_tbuonomo_andrui__viewpagerdotsindicator:apache_2_0

--- a/library-core/src/main/java/com/mikepenz/aboutlibraries/Libs.kt
+++ b/library-core/src/main/java/com/mikepenz/aboutlibraries/Libs.kt
@@ -420,6 +420,8 @@ class Libs(
                         license.licenseShortDescription = insertVariables(license.licenseShortDescription, customVariables)
                         license.licenseDescription = insertVariables(license.licenseDescription, customVariables)
                         licenses.add(license)
+                    } else {
+                        licenses.add(License("", licenseId, "", "", ""))
                     }
                 }
                 lib.licenses = licenses

--- a/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.groovy
+++ b/plugin-build/plugin/src/main/groovy/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.groovy
@@ -61,12 +61,17 @@ public class AboutLibrariesTask extends DefaultTask {
         this.outputRawFolder = getRawFolder()
         this.combinedLibrariesOutputFile = getCombinedLibrariesOutputFile()
 
-        def processor = new AboutLibrariesProcessor()
-        def libraries = processor.gatherDependencies(project, variant)
+        final def processor = new AboutLibrariesProcessor()
+        final def libraries = processor.gatherDependencies(project, variant)
 
         // Include additional licenses explicitly requested.
-        processor.additionalLicenses.each {
-            neededLicenses.add(it)
+        processor.additionalLicenses.each { final al ->
+            final def foundLicense = License.values().find { final li ->
+                li.name().equalsIgnoreCase(al) || li.id.equalsIgnoreCase(al)
+            }
+            if (foundLicense != null) {
+                neededLicenses.add(foundLicense.name())
+            }
         }
 
         def printWriter = new PrintWriter(new OutputStreamWriter(combinedLibrariesOutputFile.newOutputStream(), StandardCharsets.UTF_8), true)


### PR DESCRIPTION
- adjust logic to include additional licenses to be more flexible
  - ignore case, match by id and enum name
  - FIX #576
- fallback to empty license with only ID if provided ID does not exist
  - FIX #576
- add more sample custom files to make it easier to discover