### PR TITLE
Simplify setup with proguard | include consumer proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,10 @@ In case the plugin fails to detect a library or you're using an embedded library
 </resources> 
 ```
 
-## Usage WITHOUT gradle plugin (not recommended)
+## Usage WITHOUT gradle plugin (deprecated)
 
 If you do not want to use the gradle plugin, you need to add the legacy definition files, which will then be included in the built apk, and resolved via reflection during runtime.
+
 > NOTE: This is not recommended. Please migrate to use the gradle plugin
 
 ```gradle
@@ -337,26 +338,9 @@ implementation "com.mikepenz:aboutlibraries-definitions:${latestAboutLibsRelease
 
 ## ProGuard
 
-In case you want to minimize your resources as much as possible use the following rules (Thanks to @rubengees and @AllanWang as discussed here: https://github.com/mikepenz/AboutLibraries/issues/331)
+ProGuard / R8 rules are bundled internally with the core module.
 
-```proguard
--keepclasseswithmembers class **.R$* {
-    public static final int define_*;
-    public static final int library_*;
-}
-```
-
-Please note that the resources need to be kept to be discoverable by the library.
-
-```
-android {
-    buildTypes {
-        release {
-            shrinkResources false
-        }
-    }
-}
-```
+> Please check the configuration in regards to passing in the fields `.withFields(R.string::class.java.fields)`
 
 # Disclaimer
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,8 @@ android {
                 signingConfig signingConfigs.release
             }
             zipAlignEnabled true
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         staging {
             if (getSigningFile() != null) {

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/CustomSortActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/CustomSortActivity.kt
@@ -12,6 +12,7 @@ class CustomSortActivity : LibsActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 
         val builder = LibsBuilder()
+                .withFields(R.string::class.java.fields)
                 .withLibraries("crouton, actionbarsherlock", "showcaseview")
                 .withLibraryComparator(LibraryComparator())
 

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/ExtendActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/ExtendActivity.kt
@@ -13,7 +13,11 @@ class ExtendActivity : LibsActivity() {
         intent.putExtra(Libs.BUNDLE_LIBS, arrayOf("activeandroid", "caldroid"))
         setIntent(intent)
         */
-        intent = LibsBuilder().withLibraries("activeandroid", "caldroid").withEdgeToEdge(true).intent(this)
+        intent = LibsBuilder()
+                .withFields(R.string::class.java.fields)
+                .withLibraries("activeandroid", "caldroid")
+                .withEdgeToEdge(true)
+                .intent(this)
         super.onCreate(savedInstanceState)
     }
 }

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/FragmentActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/FragmentActivity.kt
@@ -135,6 +135,7 @@ class FragmentActivity : AppCompatActivity() {
                     R.id.action_minimalactivity.toLong() -> {
                         // create and launch an activity in minmal design without any additional modifications
                         LibsBuilder()
+                                .withFields(R.string::class.java.fields)
                                 .withAboutMinimalDesign(true)
                                 .withEdgeToEdge(true)
                                 .withActivityTitle("Open Source")
@@ -144,6 +145,7 @@ class FragmentActivity : AppCompatActivity() {
                     R.id.action_manifestactivity.toLong() -> {
                         // create and launch an activity in full design, with various configurations and adjustments
                         LibsBuilder()
+                                .withFields(R.string::class.java.fields)
                                 .withLibraries("crouton", "actionbarsherlock", "showcaseview", "glide")
                                 .withAutoDetect(false)
                                 .withLicenseShown(true)
@@ -171,6 +173,7 @@ class FragmentActivity : AppCompatActivity() {
         */
 
         val fragment = LibsBuilder()
+                .withFields(R.string::class.java.fields)
                 .withVersionShown(false)
                 .withLicenseShown(true)
                 // find ids via './gradlew findLibraries'

--- a/library-core/build.gradle
+++ b/library-core/build.gradle
@@ -11,6 +11,8 @@ android {
         versionCode release.versionCode
         versionName release.versionName
 
+        consumerProguardFiles 'consumer-proguard-rules.pro'
+
         resValue "string", "aboutlibrary_lib_version", "${versionName}"
     }
 

--- a/library-core/consumer-proguard-rules.pro
+++ b/library-core/consumer-proguard-rules.pro
@@ -1,0 +1,4 @@
+# Ensure we can discover the resources
+-keepclasseswithmembers class **.R$* {
+    public static final int define_*;
+}


### PR DESCRIPTION
- include proguard rules in core module
- remove no longer required proguard notice and replace with streamlined info
- update sample app to obfuscate in release build
- include `withFields` in the sample app code