### PR TITLE
Usability enhancements for LibraryItem

### DIFF
--- a/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/LibraryItem.kt
+++ b/library/src/main/java/com/mikepenz/aboutlibraries/ui/item/LibraryItem.kt
@@ -2,6 +2,8 @@ package com.mikepenz.aboutlibraries.ui.item
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.net.Uri
 import android.text.TextUtils
 import android.view.View
@@ -119,15 +121,16 @@ class LibraryItem(private val library: Library, private val libsBuilder: LibsBui
         }
 
         if (library.libraryWebsite.isNotEmpty() || library.repositoryLink.isNotEmpty()) {
-            holder.itemView.isClickable = true
-            holder.itemView.setOnClickListener { v ->
+            holder.card.isClickable = true
+            holder.card.rippleColor = holder.defaultRippleColor
+            holder.card.setOnClickListener { v ->
                 val consumed = LibsConfiguration.listener?.onLibraryContentClicked(v, library)
                         ?: false
                 if (!consumed) {
                     openLibraryWebsite(ctx, library.libraryWebsite.takeIf { it.isNotEmpty() } ?: library.repositoryLink)
                 }
             }
-            holder.itemView.setOnLongClickListener { v ->
+            holder.card.setOnLongClickListener { v ->
                 var consumed = LibsConfiguration.listener?.onLibraryContentLongClicked(v, library)
                         ?: false
 
@@ -138,10 +141,11 @@ class LibraryItem(private val library: Library, private val libsBuilder: LibsBui
                 consumed
             }
         } else {
-            holder.itemView.isClickable = false
-            holder.itemView.setOnTouchListener(null)
-            holder.itemView.setOnClickListener(null)
-            holder.itemView.setOnLongClickListener(null)
+            holder.card.isClickable = false
+            holder.card.rippleColor = ColorStateList.valueOf(Color.TRANSPARENT)
+            holder.card.setOnTouchListener(null)
+            holder.card.setOnClickListener(null)
+            holder.card.setOnLongClickListener(null)
         }
 
         if (library.license != null && (library.license?.licenseWebsite?.isNotEmpty() == true || libsBuilder.showLicenseDialog)) {
@@ -234,6 +238,7 @@ class LibraryItem(private val library: Library, private val libsBuilder: LibsBui
      */
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         internal var card: MaterialCardView = itemView as MaterialCardView
+        internal var defaultRippleColor: ColorStateList? = null
 
         internal var libraryName: TextView = itemView.findViewById(R.id.libraryName) as TextView
         internal var libraryCreator: TextView = itemView.findViewById(R.id.libraryCreator) as TextView
@@ -248,6 +253,7 @@ class LibraryItem(private val library: Library, private val libsBuilder: LibsBui
             val ctx = itemView.context
             ctx.resolveStyledValue {
                 card.setCardBackgroundColor(it.getColor(R.styleable.AboutLibraries_aboutLibrariesCardBackground, ctx.getThemeColor(R.attr.aboutLibrariesCardBackground, ctx.getSupportColor(R.color.about_libraries_card))))
+                defaultRippleColor = card.rippleColor
                 libraryName.setTextColor(it.getColorStateList(R.styleable.AboutLibraries_aboutLibrariesOpenSourceTitle))
                 libraryCreator.setTextColor(it.getColorStateList(R.styleable.AboutLibraries_aboutLibrariesOpenSourceText))
                 libraryDescriptionDivider.setBackgroundColor(it.getColor(R.styleable.AboutLibraries_aboutLibrariesOpenSourceDivider, ctx.getThemeColor(R.attr.aboutLibrariesOpenSourceDivider, ctx.getSupportColor(R.color.about_libraries_dividerLight_openSource))))


### PR DESCRIPTION
- update to androidx htmlCompat to style text 
- hide description section if no description is available for a library
- make sections which are not clickable, to be clickable = false
- adjust clickable area for "description" to the whole "itemView"
  - whole card click opens the library website or alternative the repositoryLink
- disabling click on a `MaterialCardView` won't prevent the ripple form happening.
- set ripple color to transparent for items without a libraryWebsite or repositoryLink