### PR TITLE
Fix license definition files not included in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ custom_author_mappings.prop // allows overwriting the authors of a library if th
 custom_exclusion_list.prop // allows excluding libraries by their id at build time
 ```
 
-See the corresponding files here for the format and content: https://github.com/mikepenz/AboutLibraries/tree/develop/library-definitions/src/main/res/raw
+See the corresponding files here for the format and content: https://github.com/mikepenz/AboutLibraries/tree/develop/aboutlibraries-definitions/src/main/res/raw
 
 ### Exclude libraries
 

--- a/plugin-build/plugin/build.gradle
+++ b/plugin-build/plugin/build.gradle
@@ -63,10 +63,10 @@ compileGroovy {
 }
 
 processResources {
-    from("../../library-definitions/src/main/res/raw/") {
+    from("../../aboutlibraries-definitions/src/main/res/raw/") {
         into 'static'
     }
-    from("../../library-definitions/src/main/res/values/") {
+    from("../../aboutlibraries-definitions/src/main/res/values/") {
         into 'values'
     }
 }


### PR DESCRIPTION
- fix paths linking to definition files
  - FIX https://github.com/mikepenz/AboutLibraries/issues/624