### PR TITLE
Remove library reliance on jcenter | Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,27 +18,27 @@ buildscript {
                 androidX        : '1.0.0',
                 cardview        : '1.0.0',
                 appcompat       : '1.2.0',
-                recyclerview    : '1.1.0',
+                recyclerview    : '1.2.0',
                 material        : '1.3.0',
-                kotlin          : "1.4.31",
+                kotlin          : "1.4.32",
                 constraintLayout: '2.0.4',
-                navigation      : "2.3.3",
+                navigation      : "2.3.5",
                 iconics         : "5.2.8",
-                detekt          : '1.15.0',
-                fastadapter     : "5.3.5",
-                materialdrawer  : "8.3.3",
+                detekt          : '1.16.0',
+                fastadapter     : "5.4.0",
+                materialdrawer  : "8.4.0",
                 coreKtx         : "1.3.2"
         ]
     }
 
     repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        google()
-        jcenter()
+        gradlePluginPortal()
         mavenLocal()
+        mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
@@ -50,9 +50,19 @@ allprojects {
     group "com.mikepenz"
 
     repositories {
-        google()
-        jcenter()
         mavenLocal()
+        mavenCentral()
+        google()
+        maven {
+            // (mp) remove when available on maven center
+            url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven"
+            content { includeGroup "org.jetbrains.kotlinx" }
+        }
+    }
+
+    configurations.all {
+        resolutionStrategy.force "org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3"
+        // (mp) remove when available on maven center
     }
 }
 


### PR DESCRIPTION
- remove jcenter repository
- update dependencies
  - recyclerView 1.2.0
  - kotlin 1.4.32
  - navigation 2.3.5
  - detekt 1.16.0
  - fastadapter, materialdrawer