### PR TITLE
Detect BSD 2-Clause license via URL, just like the 3-Clause one

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/License.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/License.kt
@@ -380,8 +380,8 @@ enum class License(val fullName: String, val id: String, val aboutLibsId: String
     Apache_2_0("Apache License 2.0", "Apache-2.0", "apache_2_0", { name, url ->
         name.contains("Apache", true) || url.endsWith("LICENSE-2.0.txt")
     }),
-    BSD_2_Clause("BSD 2-Clause \"Simplified\" License", "BSD-2-Clause", customMatcher = { name, _ ->
-        name.equals("BSD 2-Clause License", true)
+    BSD_2_Clause("BSD 2-Clause \"Simplified\" License", "BSD-2-Clause", customMatcher = { name, url ->
+        name.equals("BSD 2-Clause License", true) || url.endsWith("opensource.org/licenses/BSD-2-Clause", true)
     }),
     BSD_3_Clause("BSD 3-Clause \"New\" or \"Revised\" License", "BSD-3-Clause", customMatcher = { name, url ->
         name.equals("New BSD License", true) || name.equals("Modified BSD License", true) || name.equals("BSD 3-clause", true) ||


### PR DESCRIPTION
Fix #638 