### PR TITLE
Add android:exported attribute

### DIFF
--- a/aboutlibraries/src/main/AndroidManifest.xml
+++ b/aboutlibraries/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.mikepenz.aboutlibraries">
 
     <application>
-        <activity android:name="com.mikepenz.aboutlibraries.ui.LibsActivity" />
+        <activity android:name="com.mikepenz.aboutlibraries.ui.LibsActivity"
+            android:exported="true"/>
     </application>
 </manifest>


### PR DESCRIPTION
I believe I am getting Manifest Merger errors because of the missing attribute in this lib.

Please see [Android Dev documentation](https://developer.android.com/about/versions/12/behavior-changes-12#security):

> If your app targets Android 12 and contains activities, services, or broadcast receivers that use intent filters, you must explicitly declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute for these app components.

Setting the attribute to "false" would also fix Android 12 compatibility issues. Not sure which is preferable with this lib.