### PR TITLE
Dependency updates 2021.10.01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 100
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk
+
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
@@ -126,7 +131,7 @@ jobs:
 
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v1
+        uses: mikepenz/release-changelog-builder-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           configuration: ".github/config/configuration.json"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation "com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar"
 
     // used only tho showcase multi flavor support
-    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.1")
+    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.2")
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         ]
 
         setup = [
-                compileSdk: 30,
-                buildTools: "30.0.3",
+                compileSdk: 31,
+                buildTools: "31.0.0",
                 minSdk    : 16,
                 targetSdk : 30
         ]
@@ -17,16 +17,16 @@ buildscript {
         versions = [
                 androidX        : '1.0.0',
                 cardview        : '1.0.0',
-                appcompat       : '1.3.0',
+                appcompat       : '1.3.1',
                 recyclerview    : '1.2.1',
                 material        : '1.4.0',
-                kotlin          : "1.5.21",
-                constraintLayout: '2.0.4',
+                kotlin          : "1.5.31",
+                constraintLayout: '2.1.1',
                 navigation      : "2.3.5",
-                iconics         : "5.2.8",
+                iconics         : "5.3.1",
                 detekt          : '1.16.0',
                 fastadapter     : "5.4.1",
-                materialdrawer  : "8.4.1",
+                materialdrawer  : "8.4.3",
                 coreKtx         : "1.6.0"
         ]
     }
@@ -38,7 +38,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"


### PR DESCRIPTION
- update environment to
  - buildTools 31
  - compileSdk 31
  - build gradle 7.0.2
- dependencies
  - appcompat 1.3.1
  - kotlin 1.5.31
  - constraintLayout 2.1.1
  - iconics 5.3.1
  - materialDrawer 8.4.3
  - okhttp 4.9.2
- setup java 11 and use new version of release changelog builder