### PR TITLE
Fix dependencies included in `aboutlibraries` module

### DIFF
--- a/aboutlibraries/build.gradle
+++ b/aboutlibraries/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: "androidx.navigation.safeargs.kotlin"
-apply plugin: 'com.mikepenz.aboutlibraries.plugin' // has to be applied AFTER android
 
 version release.versionName
 


### PR DESCRIPTION
- remove plugin from `aboutlibraries` module
  - remove dependencies from UI module already
  - plugin would automatically generate resources for dependencies