### PR TITLE
Migrate to use FragmentContainerView

### DIFF
--- a/aboutlibraries/src/main/res/layout/activity_opensource.xml
+++ b/aboutlibraries/src/main/res/layout/activity_opensource.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/frame_container"
         android:layout_width="0dp"
         android:layout_height="0dp"


### PR DESCRIPTION
The `WrongFragmentContainerViolation` policy of `FragmentStrictMode` requests to use `FragmentContainerView` for parent view of all fragments.

This pull request changes to use `FragmentContainerView` in the layout file for `LibsActivity`.