### PR TITLE
Upgrade dependencies (compose-jb 1.0.0-rc3)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,7 @@ dependencies {
     implementation "com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar"
 
     // used only tho showcase multi flavor support
-    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.2")
+    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.3")
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,13 @@ buildscript {
                 buildTools: "31.0.0",
                 minSdk    : 21,
                 targetSdk : 30,
-                dokka     : "1.5.31"
+                dokka     : "1.6.0"
         ]
 
         versions = [
                 androidX            : '1.0.0',
                 activityCompose     : '1.4.0',
-                accompanist         : "0.21.2-beta",
+                accompanist         : "0.21.3-beta",
                 cardview            : '1.0.0',
                 compose             : "1.1.0-beta03",
                 appcompat           : '1.3.1',
@@ -29,9 +29,9 @@ buildscript {
                 kotlinCoroutines    : "1.5.2",
                 constraintLayout    : '2.1.2',
                 navigation          : "2.3.5",
-                iconics             : "5.3.2",
-                fastadapter         : "5.5.1",
-                materialdrawer      : "9.0.0-a02",
+                iconics             : "5.3.3",
+                fastadapter         : "5.6.0",
+                materialdrawer      : "9.0.0-a03",
                 coreKtx             : "1.7.0",
                 kotlinxSerialization: "1.3.1",
         ]
@@ -53,7 +53,7 @@ buildscript {
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:${setup.dokka}")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
         classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.0.0-beta6-dev464")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:1.0.0-rc3")
     }
 }
 


### PR DESCRIPTION
- upgrade dependencies to latest stable version
  - dokka 1.6.0
  - compose-jb 1.0.0-rc3
  - accompanist 0.21.3-beta
  - iconics 5.3.3
  - fastadapter 5.6.0
  - materialDrawer 9.0.0-a03