### PR TITLE
Kotlin 1.6.10 | Compose 1.1.0-beta04 | Compose-jb 1.0.1-rc2

### DIFF
--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -7,14 +7,14 @@ plugins {
 }
 
 val viewModel = "2.4.0"
-val composeVersion = "1.1.0-beta02"
+val composeVersion = "1.1.0-beta04"
 
 android {
     compileSdk = 31
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
     }
 
     buildTypes {
@@ -35,7 +35,7 @@ android {
     }
 
     lint {
-        isAbortOnError = false
+        //isAbortOnError = false
     }
 }
 kotlin {
@@ -53,8 +53,6 @@ dependencies {
     commonMainCompileOnly(compose.ui)
     commonMainCompileOnly(compose.foundation)
     commonMainCompileOnly(compose.material)
-
-    //"androidMainImplementation"("androidx.compose.ui:ui-tooling:$composeVersion")
 }
 
 configurations.configureEach {

--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -6,15 +6,12 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-val viewModel = "2.4.0"
-val composeVersion = "1.1.0-beta04"
-
 android {
-    compileSdk = 31
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = 21
-        targetSdk = 31
+        minSdk = libs.versions.minSdk.get().toInt()
+        targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
     buildTypes {
@@ -31,11 +28,11 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = composeVersion
+        kotlinCompilerExtensionVersion = libs.versions.compose.get()
     }
 
     lint {
-        //isAbortOnError = false
+        isAbortOnError = false
     }
 }
 kotlin {

--- a/aboutlibraries-core/build.gradle
+++ b/aboutlibraries-core/build.gradle
@@ -1,19 +1,19 @@
-apply plugin: "com.android.library"
 apply plugin: "kotlin-multiplatform"
+apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.kotlin.native.cocoapods"
 apply plugin: "org.jetbrains.dokka"
 
-version = release.versionName
+version = VERSION_NAME
 archivesBaseName = POM_ARTIFACT_ID
 
 android {
-    compileSdk = setup.compileSdk
+    compileSdk = libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdkVersion setup.minSdk
-        targetSdkVersion setup.targetSdk
-        versionCode release.versionCode
-        versionName release.versionName
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.targetSdk.get().toInteger()
+        versionName VERSION_NAME
+        versionCode Integer.parseInt(VERSION_CODE)
     }
 
     buildTypes {
@@ -98,7 +98,7 @@ kotlin {
 
 dependencies {
     // kotlinx Serialize
-    multiplatformMainImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.kotlinxSerialization}"
+    multiplatformMainImplementation(libs.kotlinx.serialization)
 }
 
 dokkaHtml.configure {

--- a/aboutlibraries/build.gradle
+++ b/aboutlibraries/build.gradle
@@ -3,16 +3,16 @@ apply plugin: "kotlin-android"
 apply plugin: "androidx.navigation.safeargs.kotlin"
 apply plugin: "org.jetbrains.dokka"
 
-version release.versionName
+version VERSION_NAME
 
 android {
-    compileSdkVersion setup.compileSdk
+    compileSdk = libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdkVersion setup.minSdk
-        targetSdkVersion setup.targetSdk
-        versionCode release.versionCode
-        versionName release.versionName
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.targetSdk.get().toInteger()
+        versionName VERSION_NAME
+        versionCode Integer.parseInt(VERSION_CODE)
     }
 
     buildTypes {
@@ -49,26 +49,25 @@ android {
 dependencies {
     api project(':aboutlibraries-core')
 
-    implementation "androidx.core:core-ktx:${versions.coreKtx}"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.viewModel}"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:${versions.viewModel}"
-    implementation "androidx.cardview:cardview:${versions.cardview}"
-    implementation "androidx.recyclerview:recyclerview:${versions.recyclerview}"
-    implementation "com.google.android.material:material:${versions.material}"
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.bundles.androidx.lifecycle)
+    implementation(libs.androidx.cardView)
+    implementation(libs.androidx.recyclerView)
+    implementation(libs.google.material)
 
     // Coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
+    implementation(libs.kotlin.coroutines.core)
 
     // add the constraintLayout used to create the items and headers
-    implementation "androidx.constraintlayout:constraintlayout:${versions.constraintLayout}"
+    implementation(libs.androidx.constraintLayout)
 
     // used to fill the RecyclerView with the items
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    implementation "com.mikepenz:fastadapter:${versions.fastadapter}"
+    implementation(libs.fastAdapter.core)
 
     // navigation
-    implementation "androidx.navigation:navigation-fragment-ktx:${versions.navigation}"
+    implementation(libs.androidx.navigation.ktx)
 }
 
 if (project.hasProperty('pushall') || project.hasProperty('library_only')) {

--- a/aboutlibraries/src/main/AndroidManifest.xml
+++ b/aboutlibraries/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     package="com.mikepenz.aboutlibraries">
 
     <application>
-        <activity android:name="com.mikepenz.aboutlibraries.ui.LibsActivity" />
+        <activity
+            android:name="com.mikepenz.aboutlibraries.ui.LibsActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.kt
+++ b/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.kt
@@ -30,6 +30,7 @@ import com.mikepenz.fastadapter.GenericItem
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -93,7 +94,7 @@ open class LibsSupportFragment : Fragment(), Filterable {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.whenStarted {
                 withContext(Dispatchers.Main) {
-                    viewModel.listItems.flowOn(Dispatchers.Main).collect {
+                    viewModel.listItems.flowOn(Dispatchers.Main).collectLatest {
                         itemAdapter.set(it)
                     }
                 }

--- a/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/viewmodel/LibsViewModelFactory.kt
+++ b/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/viewmodel/LibsViewModelFactory.kt
@@ -11,7 +11,7 @@ class LibsViewModelFactory(
     private val builder: LibsBuilder, // ui module
     private val libsBuilder: Libs.Builder
 ) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return LibsViewModel(context, builder, libsBuilder) as T
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,13 +9,13 @@ if (getSigningFile() != null) {
 }
 
 android {
-    compileSdkVersion setup.compileSdk
+    compileSdk = libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdkVersion setup.minSdk
-        targetSdkVersion setup.targetSdk
-        versionCode release.versionCode
-        versionName release.versionName
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.targetSdk.get().toInteger()
+        versionName VERSION_NAME
+        versionCode Integer.parseInt(VERSION_CODE)
         multiDexEnabled true
 
         setProperty("archivesBaseName", "AboutLibraries-v$versionName-c$versionCode")
@@ -75,7 +75,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = versions.compose
+        kotlinCompilerExtensionVersion = libs.versions.compose.get()
     }
 
     packagingOptions {
@@ -121,44 +121,38 @@ dependencies {
     implementation project(':aboutlibraries')
     implementation project(':aboutlibraries-compose')
 
-    implementation "androidx.activity:activity-compose:${versions.activityCompose}"
-    implementation "com.google.android.material:material:${versions.material}"
-    implementation "androidx.recyclerview:recyclerview:${versions.recyclerview}"
-    implementation "androidx.cardview:cardview:${versions.cardview}"
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.cardView)
+    implementation(libs.androidx.recyclerView)
 
-    implementation("com.google.accompanist:accompanist-insets-ui:${versions.accompanist}")
-    implementation("com.google.accompanist:accompanist-systemuicontroller:${versions.accompanist}")
+    implementation(libs.google.material)
 
-    implementation("androidx.compose.runtime:runtime:${versions.compose}")
-    implementation("androidx.compose.ui:ui:${versions.compose}")
-    implementation("androidx.compose.foundation:foundation-layout:${versions.compose}")
-    implementation("androidx.compose.material:material:${versions.compose}")
-    implementation("androidx.compose.foundation:foundation:${versions.compose}")
-    implementation("androidx.compose.ui:ui-tooling:${versions.compose}")
-    implementation("androidx.compose.runtime:runtime-livedata:${versions.compose}")
+    implementation(libs.bundles.accompanist)
+
+    implementation(libs.bundles.compose.androidx)
 
     //used to generate the drawer on the left
     //https://github.com/mikepenz/MaterialDrawer
-    implementation "com.mikepenz:materialdrawer:${versions.materialdrawer}"
+    implementation(libs.materialDrawer.core)
 
     //used to provide different itemAnimators for the RecyclerView
     //https://github.com/mikepenz/ItemAnimators
-    implementation 'com.mikepenz:itemanimators:1.1.0'
+    implementation(libs.itemAnimators.core)
 
     // used to provide out of the box icon font support. simplifies development,
     // and provides scalable icons. the core is very very light
     // https://github.com/mikepenz/Android-Iconics
-    implementation "com.mikepenz:iconics-core:${versions.iconics}"
+    implementation(libs.iconics.core)
 
     //used to display the icons in the drawer
     //https://github.com/mikepenz/Android-Iconicsx`
-    implementation "com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar"
+    implementation("com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar")
 
     // used only tho showcase multi flavor support
-    stagingImplementation("com.squareup.okhttp3:okhttp:4.9.3")
+    stagingImplementation(libs.okhttp.core)
 }
 
 configurations.all {
-    resolutionStrategy.force "com.mikepenz:fastadapter:${versions.fastadapter}"
-    resolutionStrategy.force "com.mikepenz:iconics-core:${versions.iconics}"
+    resolutionStrategy.force(libs.fastAdapter.core)
+    resolutionStrategy.force(libs.iconics.core)
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,10 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += [
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true"
+        ]
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <!--android:supportsRtl="true"-->
         <activity
             android:name="com.mikepenz.aboutlibraries.sample.FragmentActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/SampleApp.DayNight">
             <intent-filter>
@@ -22,14 +23,17 @@
         </activity>
         <activity
             android:name="com.mikepenz.aboutlibraries.sample.ExtendActivity"
+            android:exported="false"
             android:label="@string/app_name"
             android:theme="@style/SampleApp.DayNight" />
         <activity
             android:name="com.mikepenz.aboutlibraries.sample.CustomSortActivity"
+            android:exported="false"
             android:label="@string/app_name"
             android:theme="@style/SampleApp.DayNight" />
         <activity
             android:name="com.mikepenz.aboutlibraries.sample.ComposeActivity"
+            android:exported="false"
             android:label="@string/app_name"
             android:theme="@style/SampleApp.DayNight" />
     </application>

--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,15 @@ buildscript {
         versions = [
                 androidX            : '1.0.0',
                 activityCompose     : '1.4.0',
-                accompanist         : "0.21.3-beta",
+                accompanist         : "0.21.4-beta",
                 cardview            : '1.0.0',
-                compose             : "1.1.0-beta03",
+                compose             : "1.1.0-beta04",
                 appcompat           : '1.3.1',
                 recyclerview        : '1.2.1',
                 viewModel           : "2.4.0",
-                material            : '1.5.0-beta01',
-                kotlin              : "1.5.31",
-                kotlinCoroutines    : "1.5.2",
+                material            : '1.5.0-rc01',
+                kotlin              : "1.6.10",
+                kotlinCoroutines    : "1.6.0-RC2",
                 constraintLayout    : '2.1.2',
                 navigation          : "2.3.5",
                 iconics             : "5.3.3",
@@ -47,13 +47,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.3")
+        classpath("com.android.tools.build:gradle:7.0.4")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:${setup.dokka}")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
         classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.0.0")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:1.0.1-rc2")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,6 @@
 buildscript {
     apply from: 'configurations.gradle'
 
-    ext {
-        release = [
-                versionName: VERSION_NAME,
-                versionCode: Integer.parseInt(VERSION_CODE)
-        ]
-
-        setup = [
-                compileSdk: 31,
-                buildTools: "31.0.0",
-                minSdk    : 21,
-                targetSdk : 30,
-                dokka     : "1.6.0"
-        ]
-
-        versions = [
-                androidX            : '1.0.0',
-                activityCompose     : '1.4.0',
-                accompanist         : "0.21.4-beta",
-                cardview            : '1.0.0',
-                compose             : "1.1.0-beta04",
-                appcompat           : '1.3.1',
-                recyclerview        : '1.2.1',
-                viewModel           : "2.4.0",
-                material            : '1.5.0-rc01',
-                kotlin              : "1.6.10",
-                kotlinCoroutines    : "1.6.0-RC2",
-                constraintLayout    : '2.1.2',
-                navigation          : "2.3.5",
-                iconics             : "5.3.3",
-                fastadapter         : "5.6.0",
-                materialdrawer      : "9.0.0-a03",
-                coreKtx             : "1.7.0",
-                kotlinxSerialization: "1.3.1",
-        ]
-    }
-
     repositories {
         gradlePluginPortal()
         mavenLocal()
@@ -47,13 +11,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}")
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:${setup.dokka}")
-        classpath("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
+        classpath(libs.gradle.build)
+        classpath(libs.kotlin.plug)
+        classpath(libs.androidx.navigation.plug)
+        classpath(libs.dokka.plug)
+        classpath(libs.gradleMvnPlublish.plug)
+        classpath(libs.compose.jb.plug)
         classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.0.1-rc2")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,82 @@
+[versions]
+# android sdk versions
+compileSdk = "31"
+minSdk = "21"
+targetSdk = "31"
+# build
+gradleBuild = "7.0.4"
+buildTools = "31.0.0"
+# kotlin
+dokka = "1.6.0"
+kotlinCore = { require = "1.6.10" }
+kotlinCoroutines = { require = "1.6.0-RC2" }
+kotlinxSerialization = "1.3.1"
+# compose
+compose = "1.1.0-beta04"
+composejb = "1.0.1-rc2"
+# androidx
+activity = "1.4.0"
+cardview = "1.0.0"
+constraintLayout = "2.1.2"
+core = "1.7.0"
+lifecycle = { require = "2.4.0" }
+navigation = "2.3.5"
+recyclerView = "1.2.1"
+# google
+material = "1.5.0-rc01"
+# other
+accompanist = "0.21.4-beta"
+fastAdapter = "5.6.0"
+gradleMvnPlublish = "0.18.0"
+iconics = "5.3.3"
+itemAnimators = "1.1.0"
+ivy = "2.5.0"
+materialDrawer = "9.0.0-a03"
+okhttp = "4.9.3"
+
+[libraries]
+# build
+gradle-build = { module = "com.android.tools.build:gradle", version.ref = "gradleBuild" }
+# kotlin
+dokka-plug = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinCore" }
+kotlin-plug = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinCore" }
+kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
+kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
+kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+# compose
+compose-androidx-runtime-core = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+compose-androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
+compose-androidx-ui-core = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+compose-androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-androidx-foundation-core = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
+compose-androidx-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }
+compose-androidx-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+compose-jb-plug = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composejb" }
+# androidx
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
+androidx-cardView = { module = "androidx.cardview:cardview", version.ref = "cardview" }
+androidx-constraintLayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintLayout" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core" }
+androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-navigation-plug = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigation" }
+androidx-navigation-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
+androidx-recyclerView = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerView" }
+# google
+google-material = { module = "com.google.android.material:material", version.ref = "material" }
+# other
+accompanist-insets-ui = { module = "com.google.accompanist:accompanist-insets-ui", version.ref = "accompanist" }
+accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
+fastAdapter-core = { module = "com.mikepenz:fastadapter", version.ref = "fastAdapter" }
+gradleMvnPlublish-plug = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradleMvnPlublish" }
+iconics-core = { module = "com.mikepenz:iconics-core", version.ref = "iconics" }
+itemAnimators-core = { module = "com.mikepenz:itemanimators", version.ref = "itemAnimators" }
+ivy-core = { module = "org.apache.ivy:ivy", version.ref = "ivy" }
+materialDrawer-core = { module = "com.mikepenz:materialdrawer", version.ref = "materialDrawer" }
+okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+
+[bundles]
+accompanist = ["accompanist-insets-ui", "accompanist-systemuicontroller"]
+androidx-lifecycle = ["androidx-lifecycle-livedata-ktx", "androidx-lifecycle-viewmodel-ktx"]
+compose-androidx = ["compose-androidx-runtime-core", "compose-androidx-runtime-livedata", "compose-androidx-ui-core", "compose-androidx-ui-tooling", "compose-androidx-foundation-core", "compose-androidx-foundation-layout", "compose-androidx-material"]

--- a/plugin-build/build.gradle
+++ b/plugin-build/build.gradle
@@ -9,8 +9,8 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.0")
+        classpath(libs.kotlin.plug.get())
+        classpath(libs.dokka.plug)
     }
 }
 

--- a/plugin-build/build.gradle
+++ b/plugin-build/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.0")
     }
 }

--- a/plugin-build/plugin/build.gradle
+++ b/plugin-build/plugin/build.gradle
@@ -44,13 +44,13 @@ repositories {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")
+    implementation(libs.kotlin.stdlib)
 
     // parser the pom.xml files
-    implementation("org.apache.ivy:ivy:2.5.0")
+    implementation(libs.ivy.core)
 
     // add better android support
-    compileOnly("com.android.tools.build:gradle:7.0.4")
+    compileOnly(libs.gradle.build)
 }
 
 // generate zip file for android maven release tool

--- a/plugin-build/plugin/build.gradle
+++ b/plugin-build/plugin/build.gradle
@@ -44,13 +44,13 @@ repositories {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")
 
     // parser the pom.xml files
     implementation("org.apache.ivy:ivy:2.5.0")
 
     // add better android support
-    compileOnly("com.android.tools.build:gradle:7.0.3")
+    compileOnly("com.android.tools.build:gradle:7.0.4")
 }
 
 // generate zip file for android maven release tool

--- a/plugin-build/settings.gradle
+++ b/plugin-build/settings.gradle
@@ -1,1 +1,8 @@
 include ':plugin'
+
+enableFeaturePreview("VERSION_CATALOGS")
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs { from(files("../gradle/libs.versions.toml")) }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,11 @@ include ':app-desktop'
 includeBuild("plugin-build") {
     dependencySubstitution {
         // Set up substitution so :app uses the plugin/libs from the composite build.
-        substitute(module("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin")).with(project(":plugin"))
+        substitute(module("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin")).using(project(":plugin"))
     }
 }
+
+/**
+ * Configure gradle features
+ */
+enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
- upgrade to Kotlin 1.6.10 and coroutines 1.6.0-RC2 
- update to compose 1.1.0-beta04 (awaiting beta05 with official kotlin 1.6.10 support)
- update to compose-jb 1.0.1-rc2
- material 1.5.0-rc01
- move all dependency definitions into the libs.versions.toml 
- remove legacy dependency declaration
