### PR TITLE
Introduce new `fundLibraries` gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - Gradle Plugin
   - Generating dependency / license metadata
   - Different exports, compliance report
+  - Identify possible project funding
   - License *strict mode*
 - Simple and fast integration
 
@@ -313,7 +314,10 @@ For other environments or for more advanced usages the plugin offers additional 
 ./gradlew findLibraries
 
 # Export all dependencies in a format helpful for compliance reports
-./exportComplianceLibraries${Variant}
+./gradlew exportComplianceLibraries${Variant}
+
+# List all funding options for included projects (as identified via the e.g.: GitHub API)
+./gradlew fundLibraries
 ```
 
 # Special repository support

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesFundingTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesFundingTask.kt
@@ -1,0 +1,21 @@
+package com.mikepenz.aboutlibraries.plugin
+
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class AboutLibrariesFundingTask : BaseAboutLibrariesTask() {
+
+    @TaskAction
+    fun action() {
+        val result = createLibraryProcessor(readInCollectedDependencies()).gatherDependencies()
+        println("Libraries offering funding options:")
+        println()
+        for (library in result.libraries.filter { it.funding.isNotEmpty() }) {
+            println("${library.name} @ ${library.website ?: library.scm?.url ?: "no website"}")
+            library.funding.forEach {
+                println(" --> Sponsor via ${it.platform} @ ${it.url}")
+            }
+        }
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -31,6 +31,13 @@ class AboutLibrariesPlugin : Plugin<Project> {
                 }
             }
 
+            // task to output funding options for included libraries
+            project.tasks.register("fundLibraries", AboutLibrariesFundingTask::class.java) {
+                it.description = "Outputs the funding options for used dependencies"
+                it.group = "Help"
+                it.dependsOn(collectTask)
+            }
+
             // task to output library names with ids for further actions
             project.tasks.register("findLibraries", AboutLibrariesIdTask::class.java) {
                 it.description = "Writes the relevant meta data for the AboutLibraries plugin to display dependencies"


### PR DESCRIPTION
- introduce new task offering to list all funding options as found via the GitHub API