### PR TITLE
Ensure `local.properties` in sample is read independent of exec root

### DIFF
--- a/configurations.gradle
+++ b/configurations.gradle
@@ -20,7 +20,7 @@ import java.text.SimpleDateFormat
  */
 ext.getLocalProps = {
     Properties localProperties = new Properties()
-    localProperties.load(new File('local.properties').newDataInputStream())
+    localProperties.load(new File(project.rootDir, 'local.properties').newDataInputStream())
     return localProperties
 }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -386,7 +386,9 @@ enum class SpdxLicense(
         name.contains("Apache", true) || url?.endsWith("LICENSE-2.0.txt") == true
     }),
     BSD_2_Clause("BSD 2-Clause \"Simplified\" License", "BSD-2-Clause", customMatcher = { name, url ->
-        name.equals("BSD 2-Clause License", true) || url?.endsWith("opensource.org/licenses/BSD-2-Clause", true) == true
+        name.equals("BSD 2-Clause License", true)
+                || url?.endsWith("opensource.org/licenses/BSD-2-Clause", true) == true
+                || url?.endsWith("opensource.org/licenses/bsd-license", true) == true
     }),
     BSD_3_Clause("BSD 3-Clause \"New\" or \"Revised\" License", "BSD-3-Clause", customMatcher = { name, url ->
         name.equals("New BSD License", true) || name.equals("Modified BSD License", true) || name.equals("BSD 3-clause", true) ||


### PR DESCRIPTION
- handle local.properties independent of execution root