### PR TITLE
Add ability to provide tag for libraries (via custom configs)

### DIFF
--- a/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
+++ b/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
@@ -43,12 +43,13 @@ actual fun parseData(json: String): Result {
                 organization,
                 scm,
                 libLicenses,
-                funding
+                funding,
+                optString("tag")
             )
         }
         return Result(libraries, licenses)
     } catch (t: Throwable) {
-        Log.e("aboutlibraries", "Failed to parse aboutlibraries.json: $t")
+        Log.e("AboutLibraries", "Failed to parse the meta data *.json file: $t")
     }
     return Result(emptyList(), emptyList())
 }

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Library.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Library.kt
@@ -24,7 +24,8 @@ data class Library(
     val organization: Organization?,
     val scm: Scm?,
     val licenses: Set<License> = emptySet(),
-    val funding: Set<Funding> = emptySet()
+    val funding: Set<Funding> = emptySet(),
+    val tag: String? = null,
 ) {
     /**
      * defines the [uniqueId]:[artifactVersion] combined

--- a/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
+++ b/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
@@ -44,12 +44,13 @@ actual fun parseData(json: String): Result {
                 organization,
                 scm,
                 libLicenses,
-                funding
+                funding,
+                optString("tag")
             )
         }
         return Result(libraries, licenses)
     } catch (t: Throwable) {
-        println("Failed to parse aboutlibraries.json: $t")
+        println("Failed to parse the meta data *.json file: $t")
     }
     return Result(emptyList(), emptyList())
 }

--- a/config/libraries/lib_first.json
+++ b/config/libraries/lib_first.json
@@ -4,6 +4,7 @@
   "artifactVersion": "42.0",
   "description": "",
   "name": "ABC Custom Jetpack library",
+  "tag": "custom",
   "licenses": [
     "asdkl"
   ]

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/Library.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/Library.kt
@@ -16,7 +16,8 @@ data class Library(
     var scm: Scm?,
     var licenses: Set<String> = emptySet(),
     var funding: Set<Funding> = emptySet(),
-    var artifactFolder: File? = null
+    var tag: String? = null,
+    var artifactFolder: File? = null,
 ) {
     val artifactId: String
         get() = "${uniqueId}:${artifactVersion ?: ""}"

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
@@ -240,6 +240,7 @@ class LibrariesProcessor(
             scm,
             licenses.map { it.hash }.toSet(),
             funding,
+            null,
             artifactFile.parentFile?.parentFile // artifactFile references the pom directly
         )
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
@@ -58,6 +58,7 @@ fun Library.merge(with: Library) {
     with.name?.takeIf { it.isNotBlank() }?.also { orgLib.name = it }
     with.description?.takeIf { it.isNotBlank() }?.also { orgLib.description = it }
     with.website?.takeIf { it.isNotBlank() }?.also { orgLib.website = it }
+    with.tag?.takeIf { it.isNotBlank() }?.also { orgLib.tag = it }
 
     // merge custom data with original data
     val origOrganization = orgLib.organization

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/parser/LibraryReader.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/parser/LibraryReader.kt
@@ -55,24 +55,14 @@ object LibraryReader {
                 organization,
                 scm,
                 licenses,
-                funding
+                funding,
+                c["tag"] as? String
             )
         } catch (t: Throwable) {
             LOGGER.error("Could not read the license ($name)", t)
             null
         }
     }
-
-    /**
-    "uniqueId": "androidx.jetpack.library:custom",
-    "developers": [],
-    "artifactVersion": "42.0",
-    "description": "",
-    "name": "ABC Custom Jetpack library",
-    "licenses": [
-    "asdkl"
-    ]
-     */
 
     private val LOGGER = LoggerFactory.getLogger(LibraryReader::class.java)!!
     private const val LIBRARIES_DIR = "libraries"


### PR DESCRIPTION
- add ability to provide a `tag` on library information, which can be used to potentially organize libraries better in custom UIs
  - FIX https://github.com/mikepenz/AboutLibraries/issues/715