### PR TITLE
Add new API to Gradle Plugin allowing to exclude fields from the generated meta data json

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,10 @@ aboutLibraries {
     gitHubApiToken = getLocalOrGlobalProperty("github.pat")
 
     // Full license text for license IDs mentioned here will be included, even if no detected dependency uses them.
-    /* additionalLicenses = ["mit", "mpl_2_0"] */
+    // additionalLicenses = ["mit", "mpl_2_0"]
+
+    // Allows to exclude some fields from the generated meta data field.
+    // excludeFields = ["developers", "funding"]
 
     // Define the strict mode, will fail if the project uses licenses not allowed
     // - This will only automatically fail for Android projects which have `registerAndroidTasks` enabled

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -74,7 +74,7 @@ abstract class AboutLibrariesExtension constructor() {
      *
      * This API requires spdxId's to be provided. A full list is available here: https://spdx.org/licenses/
      */
-    var additionalLicenses: List<String> = emptyList()
+    var additionalLicenses: Array<String> = emptyArray()
 
     /**
      * Enables an exceptional strictMode which will either log or crash the build in case non allowed licenses are detected.
@@ -98,7 +98,7 @@ abstract class AboutLibrariesExtension constructor() {
      *
      * This API requires spdxId's to be provided. A full list is available here: https://spdx.org/licenses/
      */
-    var allowedLicenses: List<String> = emptyList()
+    var allowedLicenses: Array<String> = emptyArray()
 
     /**
      * Defines the plugins behavior in case of duplicates.
@@ -177,6 +177,18 @@ abstract class AboutLibrariesExtension constructor() {
      * ```
      */
     var gitHubApiToken: String? = null
+
+    /**
+     * Defines fields which will be excluded during the serialisation of the metadata output file.
+     *
+     * Any field as included in the [com.mikepenz.aboutlibraries.plugin.mapping.Library] can theoretically be excluded.
+     * ```
+     * aboutLibraries {
+     *   excludeFields = arrayOf("description", "tag")
+     * }
+     * ```
+     */
+    var excludeFields: Array<String> = emptyArray()
 }
 
 enum class StrictMode {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -74,7 +74,7 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
         }
 
         // write to disk
-        result.writeToDisk(combinedLibrariesOutputFile)
+        result.writeToDisk(combinedLibrariesOutputFile, excludeFields)
     }
 
     companion object {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -69,13 +69,14 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val fetchRemoteFunding = extension.fetchRemoteFunding && !offlineMode
 
     @Input
+    val additionalLicenses = extension.additionalLicenses.toHashSet()
+
+    @Input
     @org.gradle.api.tasks.Optional
     val gitHubApiToken = extension.gitHubApiToken
 
     @Input
-    fun getAdditionalLicenses(): HashSet<String> {
-        return extension.additionalLicenses.toHashSet()
-    }
+    val excludeFields = extension.excludeFields
 
     @Suppress("UNCHECKED_CAST")
     protected fun readInCollectedDependencies(): CollectedContainer {
@@ -95,7 +96,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
             offlineMode,
             fetchRemoteLicense,
             fetchRemoteFunding,
-            getAdditionalLicenses(),
+            additionalLicenses,
             duplicationMode,
             duplicationRule,
             variant,

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
@@ -24,10 +24,11 @@ class MetaData(
         .format(Calendar.getInstance().toInstant())
 )
 
-fun ResultContainer.writeToDisk(outputFile: File) {
-    val jsonGenerator = JsonGenerator.Options().excludeNulls().excludeFieldsByName(
-        "artifactId", "groupId", "artifactFolder"
-    ).build()
+fun ResultContainer.writeToDisk(outputFile: File, excludeFields: Array<String>) {
+    val fieldNames = mutableListOf("artifactId", "groupId", "artifactFolder").also {
+        it.addAll(excludeFields)
+    }
+    val jsonGenerator = JsonGenerator.Options().excludeNulls().excludeFieldsByName(fieldNames).build()
     PrintWriter(OutputStreamWriter(outputFile.outputStream(), StandardCharsets.UTF_8), true).use {
         it.write(jsonGenerator.toJson(this))
     }


### PR DESCRIPTION
- add additional API to the Gradle Plugin allowing to exclude fields from the generated meta data json
  - FIX https://github.com/mikepenz/AboutLibraries/issues/724
```
excludeFields = ["developers", "funding"]
```
- align type for `additionalLicenses` and `allowedLicenses` in Gradle Plugin to be an Array