### PR TITLE
Trim empty lines from license content and library name and description

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
@@ -252,7 +252,7 @@ class LibrariesProcessor(
      * Ensures and applies fixes to the library names (shorten, ...)
      */
     private fun fixLibraryName(uniqueId: String, value: String): String {
-        return if (value.startsWith("Android Support Library")) {
+        return (if (value.startsWith("Android Support Library")) {
             value.replace("Android Support Library", "Support")
         } else if (value.startsWith("Android Support")) {
             value.replace("Android Support", "Support")
@@ -260,14 +260,14 @@ class LibrariesProcessor(
             value.replace("org.jetbrains.kotlin:", "")
         } else {
             value
-        }
+        }).trimIndent()
     }
 
     /**
      * Ensures and applies fixes to the library descriptions (remove 'null', ...)
      */
     private fun fixLibraryDescription(value: String): String {
-        return value.takeIf { it != "null" } ?: ""
+        return value.takeIf { it != "null" }?.trimIndent() ?: ""
     }
 
     /**

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
@@ -18,7 +18,7 @@ object LicenseUtil {
             } else {
                 remoteLicenseCache[url] = ""
                 URL(url).readText().also {
-                    remoteLicenseCache[url] = it
+                    remoteLicenseCache[url] = it.trimIndent() // cleanup empty lines before and after, and any indent.
                 }
             }
         } catch (t: Throwable) {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
@@ -17,8 +17,10 @@ object LicenseUtil {
                 remoteLicenseCache[url]
             } else {
                 remoteLicenseCache[url] = ""
-                URL(url).readText().also {
-                    remoteLicenseCache[url] = it.trimIndent() // cleanup empty lines before and after, and any indent.
+                URL(url).readText().let {
+                    val trimmed = it.trimIndent() // cleanup empty lines before and after, and any indent.
+                    remoteLicenseCache[url] = trimmed
+                    trimmed
                 }
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
- Use trimIndent on license content loaded for more consistent visualisation, and for better merging
- Use `trimIndent` on library name and description for more consistent visualisation
  - FIX #725