### PR TITLE
Fallback for miss-configured library name in pom file

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
@@ -261,6 +261,8 @@ class LibrariesProcessor(
             value.replace("Android Support", "Support")
         } else if (value.startsWith("org.jetbrains.kotlin:")) {
             value.replace("org.jetbrains.kotlin:", "")
+        } else if (value == "\${project.groupId}:\${project.artifactId}") {
+            uniqueId
         } else {
             value
         }).trimIndent()


### PR DESCRIPTION
- fallback to uniqueId in case of dependency name being wrong in the pom file
  - FIX https://github.com/mikepenz/AboutLibraries/issues/741