### PR TITLE
Dependency updates | material-components 1.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreMinSdk = "19"
 minSdk = "21"
 targetSdk = "31"
 # build
-gradleBuild = "7.1.2"
+gradleBuild = "7.2.0"
 buildTools = "32.0.0"
 # kotlin
 dokka = "1.6.10"
@@ -15,7 +15,7 @@ kotlinxSerialization = "1.3.2"
 # compose
 compose = "1.1.1"
 composeCompiler = "1.1.1"
-composejb = "1.1.0"
+composejb = "1.1.1"
 # androidx
 activity = "1.4.0"
 cardview = "1.0.0"
@@ -25,7 +25,7 @@ lifecycle = { require = "2.4.1" }
 navigation = "2.4.1"
 recyclerView = "1.2.1"
 # google
-material = "1.5.0"
+material = "1.6.0"
 # other
 accompanist = "0.23.1"
 fastAdapter = "5.6.0"
@@ -33,7 +33,7 @@ gradleMvnPublish = "0.18.0"
 iconics = "5.3.3"
 itemAnimators = "1.1.0"
 ivy = "2.5.0"
-materialDrawer = "9.0.0-b01"
+materialDrawer = "9.0.0"
 okhttp = "4.9.3"
 
 [libraries]


### PR DESCRIPTION
- update to gradle build 7.2.0
- compose-jb 1.1.1
- material 1.6.0
- materialDrawer 9.0.0