### PR TITLE
Introduce support for custom header in compose UI

### DIFF
--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -52,6 +53,7 @@ fun LibrariesContainer(
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
+    header: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
 ) {
     val libraries = remember { mutableStateOf<Libs?>(null) }
@@ -74,6 +76,7 @@ fun LibrariesContainer(
             colors,
             padding,
             itemContentPadding,
+            header,
             onLibraryClick
         )
     }
@@ -95,9 +98,15 @@ fun Libraries(
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
+    header: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
 ) {
     LazyColumn(modifier, state = lazyListState, contentPadding = contentPadding) {
+
+        if(header != null) {
+            header()
+        }
+
         items(libraries) { library ->
             val openDialog = rememberSaveable { mutableStateOf(false) }
 

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
@@ -3,18 +3,23 @@ package com.mikepenz.aboutlibraries.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.ProvideWindowInsets
@@ -43,7 +48,7 @@ class ComposeActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MainLayout() {
     MaterialTheme(
@@ -75,16 +80,22 @@ fun MainLayout() {
                 },
             ) { contentPadding ->
                 LibrariesContainer(
-                    Modifier.fillMaxSize(),
-                    contentPadding = rememberInsetsPaddingValues(
-                        insets = LocalWindowInsets.current.systemBars,
-                        additionalTop = contentPadding.calculateTopPadding(),
-                        applyTop = false,
-                        applyBottom = true
-                    ),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(top = contentPadding.calculateTopPadding()),
                     showAuthor = showAuthor,
                     showVersion = showVersion,
-                    showLicenseBadges = showLicenseBadges
+                    showLicenseBadges = showLicenseBadges,
+                    header = {
+                        stickyHeader {
+                            Column(
+                                modifier = Modifier.fillMaxWidth().background(MaterialTheme.colors.surface).padding(vertical = 25.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                Text("ExampleHeader")
+                            }
+                        }
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
@@ -83,6 +83,9 @@ fun MainLayout() {
                     Modifier
                         .fillMaxSize()
                         .padding(top = contentPadding.calculateTopPadding()),
+                    contentPadding = rememberInsetsPaddingValues(
+                        insets = LocalWindowInsets.current.systemBars,
+                    ),
                     showAuthor = showAuthor,
                     showVersion = showVersion,
                     showLicenseBadges = showLicenseBadges,
@@ -101,3 +104,8 @@ fun MainLayout() {
         }
     }
 }
+
+/*
+  Modifier
+                        .fillMaxSize()
+ */


### PR DESCRIPTION
this feature enables to use the LazyListScope to add a custom sticky header by using `stickyHeader` or a non sticky one by adding a custom `item` inside the header block.

It also adds an ExampleHeader to the compose activity, therefore how the padding needs to be applied has changed.
The values that were set to the default values were removed because it's not necessary.

This PR is mainly for people who want to use the compose implementation with a non sticky header because the `LazyColumn` implementation would make it hard to add an element above that scrolls with the `LazyColumn` together.