### PR TITLE
Introduce support for `platform` dependencies to be included in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ aboutLibraries {
     additionalLicenses = ["mit", "mpl_2_0"]
     // Allows to exclude some fields from the generated meta data field.
     excludeFields = ["developers", "funding"]
+    // Enable inclusion of `platform` dependencies in the library report
+    includePlatform = true
     // Define the strict mode, will fail if the project uses licenses not allowed
     // - This will only automatically fail for Android projects which have `registerAndroidTasks` enabled
     // For non Android projects, execute `exportLibraryDefinitions`
@@ -350,9 +352,9 @@ For other environments or for more advanced usages the plugin offers additional 
 ```
 
 # Special repository support
-|Host|License|Funding|
-|---|---|---|
-|[GitHub](https://github.com/)|x|x|
+| Host                          | License | Funding |
+|-------------------------------|---------|---------|
+| [GitHub](https://github.com/) | x       | x       |
 
 # Disclaimer
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
@@ -9,6 +9,12 @@ import java.io.File
 @CacheableTask
 abstract class AboutLibrariesCollectorTask : DefaultTask() {
 
+    @Internal
+    protected val extension = project.extensions.getByName("aboutLibraries") as AboutLibrariesExtension
+
+    @Input
+    val includePlatform = extension.includePlatform
+
     /** holds the collected set of dependencies*/
     @Internal
     protected lateinit var collectedDependencies: CollectedContainer
@@ -23,7 +29,7 @@ abstract class AboutLibrariesCollectorTask : DefaultTask() {
      */
     fun configure() {
         project.evaluationDependsOnChildren()
-        collectedDependencies = DependencyCollector().collect(project)
+        collectedDependencies = DependencyCollector(includePlatform).collect(project)
     }
 
     @TaskAction

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -75,6 +75,20 @@ abstract class AboutLibrariesExtension {
     var exclusionPatterns: List<Pattern> = emptyList()
 
     /**
+     * Enable the inclusion of platform dependencies in the report.
+     * By default `platform` level `bom` specifications will be included in the report.
+     *
+     * > Gradle provides support for importing bill of materials (BOM) files, which are effectively .pom files that use <dependencyManagement> to control the dependency versions of direct and transitive dependencies. The BOM support in Gradle works similar to using <scope>import</scope> when depending on a BOM in Maven.
+     *
+     * ```
+     * aboutLibraries {
+     *      includePlatform = false
+     * }
+     * ```
+     */
+    var includePlatform: Boolean = true
+
+    /**
      * Additional license descriptors to include in the generated `aboutlibs.json` file.
      *
      * Useful in case e.g. there's a license only used in an explicitly-added library.

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
@@ -2,6 +2,13 @@ package com.mikepenz.aboutlibraries.plugin.util
 
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.artifacts.ResolvedModuleVersion
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import java.io.File
 import java.security.MessageDigest
 
 internal fun String.toMD5(): String {
@@ -41,4 +48,31 @@ internal fun <T> chooseValue(uniqueId: String, key: String, value: Array<T>?, bl
     } else {
         value
     }
+}
+
+/**
+ * Convenient helper to wrap a [ResolvedDependency] into a []ResolvedArtifact]
+ * Required to handle `platform` dependencies.
+ */
+internal fun ResolvedDependency.toResolvedBomArtifact() = object : ResolvedArtifact {
+    override fun getFile(): File? = null
+    override fun getModuleVersion(): ResolvedModuleVersion = module
+    override fun getName(): String = this@toResolvedBomArtifact.moduleName
+    override fun getType(): String = "platform"
+    override fun getExtension(): String = "pom"
+    override fun getClassifier(): String? = null
+    override fun getId() = object : ComponentArtifactIdentifier {
+        override fun getComponentIdentifier() = object : ModuleComponentIdentifier {
+            override fun getDisplayName(): String = this@toResolvedBomArtifact.module.id.toString()
+            override fun getGroup(): String = this@toResolvedBomArtifact.module.id.module.group
+            override fun getModule(): String = this@toResolvedBomArtifact.module.id.module.name
+            override fun getVersion(): String = this@toResolvedBomArtifact.module.id.version
+            override fun getModuleIdentifier(): ModuleIdentifier = this@toResolvedBomArtifact.module.id.module
+        }
+
+        override fun getDisplayName(): String = module.id.toString()
+        override fun toString(): String = displayName
+    }
+
+    override fun toString(): String = id.displayName
 }


### PR DESCRIPTION
- introduce support to collect `platform` specifications in the dependency report
  - FIX https://github.com/mikepenz/AboutLibraries/issues/783
- introduce new configuration `includePlatform` flag, allowing to disable the collection and inclusion of platform dependencies (on by default)