### PR TITLE
Use `colorControlNormal` for `SearchView`'s `EditText` color

### DIFF
--- a/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsActivity.kt
+++ b/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsActivity.kt
@@ -15,6 +15,7 @@ import com.mikepenz.aboutlibraries.LibsBuilder.Companion.BUNDLE_TITLE
 import com.mikepenz.aboutlibraries.R
 import com.mikepenz.aboutlibraries.util.applyEdgeSystemUi
 import com.mikepenz.aboutlibraries.util.doOnApplySystemWindowInsets
+import com.mikepenz.aboutlibraries.util.getThemeColor
 
 
 /**
@@ -70,8 +71,10 @@ open class LibsActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
             menuInflater.inflate(R.menu.menu_aboutlibs, menu)
             val searchView = menu.findItem(R.id.action_menu_search).actionView as? SearchView
             val editText = searchView?.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)
-            editText?.setTextColor(Color.WHITE)
-            editText?.setHintTextColor(Color.WHITE)
+
+            editText?.setTextColor(searchView.context.getThemeColor(R.attr.colorControlNormal))
+            editText?.setHintTextColor(searchView.context.getThemeColor(R.attr.colorControlNormal))
+
             searchView?.maxWidth = Int.MAX_VALUE
             searchView?.setOnQueryTextListener(this)
         }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="customTestColor">#000</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,6 @@
     <color name="colorPrimary">#2196F3</color>
     <color name="colorPrimaryDark">#1976D2</color>
     <color name="colorAccent">#FF4081</color>
+
+    <color name="customTestColor">#FFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,7 +13,7 @@
         <item name="windowActionModeOverlay">true</item>
 
         <item name="toolbarStyle">@style/CustomToolbarStyle</item>
-        <item name="colorControlNormal">@android:color/white</item>
+        <item name="colorControlNormal">@color/customTestColor</item>
     </style>
 
     <style name="CustomToolbarStyle" parent="Widget.Material3.Toolbar">
@@ -23,10 +23,10 @@
     </style>
 
     <style name="CustomTitleTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/customTestColor</item>
     </style>
 
     <style name="CustomSubTitleTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Subtitle">
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/customTestColor</item>
     </style>
 </resources>


### PR DESCRIPTION
- use the colorControlNormal instead of a hardcoded WHITE for the searchView `editText`
  - FIX #789
- use a custom color for dark theme to make toolbar text easier to read