### PR TITLE
Remove usage of experimental `DialogProperties`

### DIFF
--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.widget.TextView
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -16,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -25,7 +23,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.window.DialogProperties
 import androidx.core.text.HtmlCompat
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
@@ -126,7 +123,6 @@ fun Libraries(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LicenseDialog(
     library: Library,
@@ -155,8 +151,6 @@ fun LicenseDialog(
                 )
             }
         },
-        modifier = Modifier.padding(16.dp),
-        properties = DialogProperties(usePlatformDefaultWidth = false),
     )
 }
 


### PR DESCRIPTION
- fix compatibility issue with different compose variants due to `DialogProperties`
  - FIX https://github.com/mikepenz/AboutLibraries/issues/796