### PR TITLE
iOS and MacOS for Compose Module Support

### DIFF
--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -50,17 +50,46 @@ kotlin {
     android {
         publishLibraryVariants("release")
     }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+
+    sourceSets {
+        val commonMain by getting
+        val commonTest by getting
+        val nonAndroidMain by creating {
+            dependsOn(commonMain)
+        }
+        val nonAndroidTest by creating {
+            dependsOn(commonTest)
+        }
+
+        listOf(
+            "jvm",
+            "iosX64",
+            "iosArm64",
+            "iosSimulatorArm64",
+            "macosX64",
+            "macosArm64"
+        ).forEach {
+            getByName(it + "Main").dependsOn(nonAndroidMain)
+            getByName(it + "Test").dependsOn(nonAndroidTest)
+        }
+    }
 }
 
 dependencies {
     commonMainImplementation(project(":aboutlibraries-core"))
 
-    commonMainCompileOnly(compose.runtime)
-    commonMainCompileOnly(compose.ui)
-    commonMainCompileOnly(compose.foundation)
-    commonMainCompileOnly(compose.material)
-    commonMainCompileOnly(compose.preview)
-    debugCompileOnly(compose.uiTooling)
+    commonMainApi(compose.runtime)
+    commonMainApi(compose.ui)
+    commonMainApi(compose.foundation)
+    commonMainApi(compose.material)
+    //commonMainApi(compose.preview)
+    debugApi(compose.uiTooling)
 
     "androidMainImplementation"(libs.androidx.core.ktx)
 }

--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.widget.TextView
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -12,8 +11,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +28,8 @@ import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.data.fakeData
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Displays all provided libraries in a simple list.
@@ -50,75 +51,43 @@ fun LibrariesContainer(
     header: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
 ) {
-    val libraries = remember { mutableStateOf<Libs?>(null) }
-
     val context = LocalContext.current
-    LaunchedEffect(libraries) {
-        libraries.value = librariesBlock.invoke(context)
+    val libraries = produceState<Libs?>(null) {
+        value = withContext(Dispatchers.IO) {
+            librariesBlock(context)
+        }
     }
 
     val libs = libraries.value?.libraries
     if (libs != null) {
+        val openDialog = remember { mutableStateOf<Library?>(null) }
+
         Libraries(
             libraries = libs,
-            modifier,
-            lazyListState,
-            contentPadding,
-            showAuthor,
-            showVersion,
-            showLicenseBadges,
-            colors,
-            padding,
-            itemContentPadding,
-            header,
-            onLibraryClick
+            modifier = modifier,
+            lazyListState = lazyListState,
+            contentPadding = contentPadding,
+            showAuthor = showAuthor,
+            showVersion = showVersion,
+            showLicenseBadges = showLicenseBadges,
+            colors = colors,
+            padding = padding,
+            itemContentPadding = itemContentPadding,
+            header = header,
+            onLibraryClick = { library ->
+                if (onLibraryClick != null) {
+                    onLibraryClick(library)
+                } else if (!library.licenses.firstOrNull()?.htmlReadyLicenseContent.isNullOrBlank()) {
+                    openDialog.value = library
+                }
+            },
         )
-    }
-}
 
-/**
- * Displays all provided libraries in a simple list.
- */
-@Composable
-fun Libraries(
-    libraries: List<Library>,
-    modifier: Modifier = Modifier,
-    lazyListState: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(0.dp),
-    showAuthor: Boolean = true,
-    showVersion: Boolean = true,
-    showLicenseBadges: Boolean = true,
-    colors: LibraryColors = LibraryDefaults.libraryColors(),
-    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
-    itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
-    header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
-) {
-    val openDialog = remember { mutableStateOf<Library?>(null) }
-
-    LazyColumn(modifier, state = lazyListState, contentPadding = contentPadding) {
-        header?.invoke(this)
-        libraryItems(
-            libraries,
-            showAuthor,
-            showVersion,
-            showLicenseBadges,
-            colors,
-            padding,
-            itemContentPadding
-        ) { library ->
-            if (onLibraryClick != null) {
-                onLibraryClick(library)
-            } else if (!library.licenses.firstOrNull()?.htmlReadyLicenseContent.isNullOrBlank()) {
-                openDialog.value = library
+        val library = openDialog.value
+        if (library != null) {
+            LicenseDialog(library = library, colors) {
+                openDialog.value = null
             }
-        }
-    }
-
-    val library = openDialog.value
-    if (library != null) {
-        LicenseDialog(library = library, colors) {
-            openDialog.value = null
         }
     }
 }
@@ -133,12 +102,10 @@ fun LicenseDialog(
     AlertDialog(
         backgroundColor = colors.backgroundColor,
         contentColor = colors.contentColor,
-        onDismissRequest = {
-            onDismiss()
-        },
+        onDismissRequest = onDismiss,
         confirmButton = {
-            TextButton(onClick = { onDismiss() }) {
-                Text(stringResource(id = R.string.aboutlibs_ok))
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(id = android.R.string.ok))
             }
         },
         text = {

--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/data/FakeData.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/data/FakeData.kt
@@ -2,7 +2,7 @@ package com.mikepenz.aboutlibraries.ui.compose.data
 
 import com.mikepenz.aboutlibraries.Libs
 
-val fakeData: Libs
+internal val fakeData: Libs
     get() = Libs.Builder().withJson(
         """
             {

--- a/aboutlibraries-compose/src/androidMain/res/values/strings.xml
+++ b/aboutlibraries-compose/src/androidMain/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="aboutlibs_ok">OK</string>
-</resources>

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -3,8 +3,11 @@ package com.mikepenz.aboutlibraries.ui.compose
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Badge
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -20,6 +23,40 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.util.author
+
+/**
+ * Displays all provided libraries in a simple list.
+ */
+@Composable
+fun Libraries(
+    libraries: List<Library>,
+    modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    showAuthor: Boolean = true,
+    showVersion: Boolean = true,
+    showLicenseBadges: Boolean = true,
+    colors: LibraryColors = LibraryDefaults.libraryColors(),
+    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
+    itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
+    header: (LazyListScope.() -> Unit)? = null,
+    onLibraryClick: ((Library) -> Unit)? = null,
+) {
+    LazyColumn(modifier, state = lazyListState, contentPadding = contentPadding) {
+        header?.invoke(this)
+        libraryItems(
+            libraries,
+            showAuthor,
+            showVersion,
+            showLicenseBadges,
+            colors,
+            padding,
+            itemContentPadding
+        ) {
+            onLibraryClick?.invoke(it)
+        }
+    }
+}
 
 internal inline fun LazyListScope.libraryItems(
     libraries: List<Library>,

--- a/aboutlibraries-compose/src/nonAndroidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/nonAndroidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -1,18 +1,17 @@
 package com.mikepenz.aboutlibraries.ui.compose
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Displays all provided libraries in a simple list.
@@ -66,9 +65,10 @@ fun LibrariesContainer(
     header: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
 ) {
-    val libraries = remember { mutableStateOf<Libs?>(null) }
-    LaunchedEffect(libraries) {
-        libraries.value = librariesBlock.invoke()
+    val libraries = produceState<Libs?>(null) {
+        value = withContext(Dispatchers.Default) {
+            librariesBlock()
+        }
     }
 
     val libs = libraries.value?.libraries
@@ -87,38 +87,5 @@ fun LibrariesContainer(
             header,
             onLibraryClick
         )
-    }
-}
-
-/**
- * Displays all provided libraries in a simple list.
- */
-@Composable
-fun Libraries(
-    libraries: List<Library>,
-    modifier: Modifier = Modifier,
-    lazyListState: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(0.dp),
-    showAuthor: Boolean = true,
-    showVersion: Boolean = true,
-    showLicenseBadges: Boolean = true,
-    colors: LibraryColors = LibraryDefaults.libraryColors(),
-    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
-    itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
-    header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
-) {
-    LazyColumn(modifier, state = lazyListState, contentPadding = contentPadding) {
-        header?.invoke(this)
-        libraryItems(
-            libraries,
-            showAuthor,
-            showVersion,
-            showLicenseBadges,
-            colors,
-            padding,
-            itemContentPadding) {
-            onLibraryClick?.invoke(it)
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ android.enableJetifier=false
 
 org.gradle.unsafe.configuration-cache=false
 android.disableAutomaticComponentCreation=true
+org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,9 @@ kotlinCore = { require = "1.7.20" }
 kotlinCoroutines = { require = "1.6.4" }
 kotlinxSerialization = "1.4.0"
 # compose
-compose = "1.3.0"
+compose = "1.2.1"
 composeCompiler = "1.3.2"
-composejb = "1.3.0-alpha01-dev831"
+composejb = "1.2.1"
 # androidx
 activity = "1.6.1"
 cardview = "1.0.0"


### PR DESCRIPTION
I did not update the CI github action as it looks more complicated then I normally work with.

Add iOS and MacOS support

Revert updates to Compose Multiplatform and Jetpack Compose from 1.3.0 to 1.2.1, this is done for multiple reasons
1.  Kotlin native does not support `compileOnly` so you have to use `api`, but that makes it so if the consumer is not using the Compose Multiplatform Beta, it will conflict with the current dependencies.
2.  There were no api changes in the code that the compose module uses so there is no requirement to update them

Commonize `Libraries` composable and move dialog opening to `LibrariesContainer` in the android source-set

Remove useless `OK` string from android source-set, use the `android.R` one.

Make fakeData internal

Use `produceState` with background dispatcher instead of `mutableStateOf` + `LaunchedEffect`