### PR TITLE
Fix default color for HtmlText and dark theme

### DIFF
--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -155,7 +155,11 @@ fun LicenseDialog(
 }
 
 @Composable
-fun HtmlText(html: String, modifier: Modifier = Modifier, color: Color = Color.Black) {
+fun HtmlText(
+    html: String,
+    modifier: Modifier = Modifier,
+    color: Color = LibraryDefaults.libraryColors().contentColor
+) {
     AndroidView(modifier = modifier, factory = { context ->
         TextView(context).apply {
             setTextColor(color.toArgb())


### PR DESCRIPTION
This PR fixes an issue I found when using `HtmlText` together with a Dark theme:

![image](https://user-images.githubusercontent.com/273338/203599123-535b2ad2-6a95-423c-aa36-0b5c4660dae2.png)

Instead of hard-coding the default color of this Composable to `Color.Black`, it now uses the `LibraryDefaults.libraryColors().contentColor`, that properly support Light and Dark themes.