### PR TITLE
Fix plugin mistakenly filtering build variants containing `test` in the name

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -122,8 +122,8 @@ class DependencyCollector(
      */
     private val testCompile = setOf("testCompile", "androidTestCompile")
     private val Configuration.isTest
-        get() = name.contains("test", ignoreCase = true) ||
-                name.contains("androidTest", ignoreCase = true) ||
+        get() = name.startsWith("test", ignoreCase = true) ||
+                name.startsWith("androidTest", ignoreCase = true) ||
                 hierarchy.any { configurationHierarchy ->
                     testCompile.any { configurationHierarchy.name.contains(it, ignoreCase = true) }
                 }


### PR DESCRIPTION
- Do not mistakenly filter out variants as test if they contain the name `test`
  - FIX https://github.com/mikepenz/AboutLibraries/issues/817