### PR TITLE
API core library in compose module

### DIFF
--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -83,7 +83,7 @@ kotlin {
 }
 
 dependencies {
-    commonMainImplementation(project(":aboutlibraries-core"))
+    commonMainApi(project(":aboutlibraries-core"))
 
     commonMainImplementation(compose.runtime)
     commonMainImplementation(compose.ui)


### PR DESCRIPTION
Currently we cannot access any of the core features from the compose library as it's in implementation scope only.

That even causes some trouble accessing features of the compose library, e.g.:

```kotlin
LibrariesContainer(
aboutLibsJson = loadJson(),
onLibraryClick = { library -> 
    // we cannot access this library here
    println(library.website) // Cannot access class 'com.mikepenz.aboutlibraries.entity.Library'. Check your module classpath for missing or conflicting dependencies
})
```

We're currently required to add the core library as well even though it's already "shipped" by the compose library.
That may produce more errors if the versions mismatch.