### PR TITLE
Allow changing typography

### DIFF
--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -92,9 +92,9 @@ internal fun Library(
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     contentPadding: PaddingValues = LibraryDefaults.ContentPadding,
+    typography: Typography = MaterialTheme.typography,
     onClick: () -> Unit,
 ) {
-    val typography = MaterialTheme.typography
     Column(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
When using import androidx.compose.material3 and ProGuard, I was receiving this error:
```
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/compose/material/MaterialTheme;
    at com.mikepenz.aboutlibraries.ui.compose.SharedLibrariesKt.Library(Unknown Source:95)
```

By making this a parameter, I can override it from my code so that androidx.compose.material.MaterialTheme is never accessed. I did try adding keep rules to R8 but it doesn't seem to fix the issue. Since there is not even any reflection, I don't know why it's broken in the first place.

(sorry about the added newline at the EOF, silly github web added it)