### PR TITLE
Set JVM target version to 11 for Gradle Plugin

### DIFF
--- a/plugin-build/plugin/build.gradle
+++ b/plugin-build/plugin/build.gradle
@@ -41,6 +41,15 @@ repositories {
     mavenCentral()
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    jvmToolchain(11)
+}
+
 dependencies {
     implementation gradleApi()
     implementation localGroovy()


### PR DESCRIPTION
- set java and kotlin jvm version to 11 for plugin
  - FIX https://github.com/mikepenz/AboutLibraries/issues/849