### PR TITLE
Add new configuration API to filter variants to cover during `collectDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ aboutLibraries {
     duplicationRule = com.mikepenz.aboutlibraries.plugin.DuplicateRule.SIMPLE
     // Enable pretty printing for the generated JSON file
     prettyPrint = false
+    // Allows to only collect dependencies of specific variants during the `collectDependencies` step.
+    filterVariants = ["debug", "release"]
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,9 @@ aboutLibraries {
     duplicationRule = com.mikepenz.aboutlibraries.plugin.DuplicateRule.SIMPLE
     // Enable pretty printing for the generated JSON file
     prettyPrint = true
+
+    // Allows to only collect dependencies of specific variants during the `collectDependencies` step.
+    // filterVariants = ["debug"]
 }
 
 dependencies {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
@@ -15,6 +15,9 @@ abstract class AboutLibrariesCollectorTask : DefaultTask() {
     @Input
     val includePlatform = extension.includePlatform
 
+    @Input
+    val filterVariants = extension.filterVariants
+
     /** holds the collected set of dependencies*/
     @Internal
     protected lateinit var collectedDependencies: CollectedContainer
@@ -29,7 +32,7 @@ abstract class AboutLibrariesCollectorTask : DefaultTask() {
      */
     fun configure() {
         project.evaluationDependsOnChildren()
-        collectedDependencies = DependencyCollector(includePlatform).collect(project)
+        collectedDependencies = DependencyCollector(includePlatform, filterVariants).collect(project)
     }
 
     @TaskAction

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -227,6 +227,17 @@ abstract class AboutLibrariesExtension {
      * ```
      */
     var prettyPrint: Boolean = false
+
+    /**
+     * Defines the variants to keep during the "collectDependencies" step.
+     *
+     * ```
+     * aboutLibraries {
+     *   filterVariants = arrayOf("debug")
+     * }
+     * ```
+     */
+    var filterVariants: Array<String> = emptyArray()
 }
 
 enum class StrictMode {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory
  */
 class DependencyCollector(
     private val includePlatform: Boolean = false,
+    private val filterVariants: Array<String> = emptyArray(),
 ) {
     /**
      * Generates the project dependency report structure
@@ -50,12 +51,20 @@ class DependencyCollector(
 
                 if (cn.endsWith("CompileClasspath", true)) {
                     val variant = cn.removeSuffix("CompileClasspath")
-                    LOGGER.info("Collecting dependencies for compile time variant $variant from config: ${it.name}")
-                    return@mapNotNull variant to it
+                    if (filterVariants.isEmpty() || filterVariants.contains(variant)) {
+                        LOGGER.info("Collecting dependencies for compile time variant $variant from config: ${it.name}")
+                        return@mapNotNull variant to it
+                    } else {
+                        LOGGER.info("Skipping compile time variant $variant from config: ${it.name}")
+                    }
                 } else if (cn.endsWith("RuntimeClasspath", true)) {
                     val variant = cn.removeSuffix("RuntimeClasspath")
-                    LOGGER.info("Collecting dependencies for runtime variant $variant from config: ${it.name}")
-                    return@mapNotNull variant to it
+                    if (filterVariants.isEmpty() || filterVariants.contains(variant)) {
+                        LOGGER.info("Collecting dependencies for runtime variant $variant from config: ${it.name}")
+                        return@mapNotNull variant to it
+                    } else {
+                        LOGGER.info("Skipping compile time variant $variant from config: ${it.name}")
+                    }
                 }
 
                 null


### PR DESCRIPTION
- add support to filter for specific variants during the `collectDependencies` step
  - FIX https://github.com/mikepenz/AboutLibraries/issues/859