### PR TITLE
Sort content prior to writing it into json for reproducible builds

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -39,7 +39,8 @@ class DependencyCollector(
     fun collect(project: Project): CollectedContainer {
         LOGGER.info("Collecting dependencies")
 
-        val mutableCollectContainer: MutableMap<String, MutableMap<String, MutableSet<String>>> = mutableMapOf()
+        val mutableCollectContainer: MutableMap<String, MutableMap<String, MutableSet<String>>> =
+            sortedMapOf(compareBy<String> { it })
 
         project.configurations
             .filterNot { configuration ->
@@ -70,7 +71,7 @@ class DependencyCollector(
                 null
             }
             .forEach { (variant, configuration) ->
-                val variantSet = mutableCollectContainer.getOrPut(variant) { mutableMapOf() }
+                val variantSet = mutableCollectContainer.getOrPut(variant) { sortedMapOf(compareBy<String> { it }) }
                 val visitedDependencyNames = mutableSetOf<String>()
                 configuration
                     .resolvedConfiguration
@@ -79,9 +80,10 @@ class DependencyCollector(
                     .getResolvedArtifacts(visitedDependencyNames)
                     .forEach { resArtifact ->
                         val identifier = "${resArtifact.moduleVersion.id.group.trim()}:${resArtifact.name.trim()}"
-                        val versions = variantSet.getOrPut(identifier) { HashSet() }
+                        val versions = variantSet.getOrPut(identifier) { LinkedHashSet() }
                         versions.add(resArtifact.moduleVersion.id.version.trim())
                     }
+
             }
         return CollectedContainer(mutableCollectContainer)
     }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
@@ -44,7 +44,7 @@ class LibrariesProcessor(
         LOGGER.info("All dependencies.size = ${collectedDependencies.size}")
 
         val librariesList = ArrayList<Library>()
-        val licensesMap = HashMap<String, License>()
+        val licensesMap = sortedMapOf<String, License>(compareBy { it })
         for (dependency in collectedDependencies) {
             val groupArtifact = dependency.key.split(":")
             val version = dependency.value.first()
@@ -135,7 +135,10 @@ class LibrariesProcessor(
             }
         }
 
-        return ResultContainer(librariesList.processDuplicates(duplicationMode, duplicationRule), licensesMap)
+        return ResultContainer(
+            librariesList.processDuplicates(duplicationMode, duplicationRule).sortedBy { it.uniqueId },
+            licensesMap
+        )
     }
 
     private fun parseDependency(artifactFile: File): Pair<Library, Set<License>>? {


### PR DESCRIPTION
- sort the json content prior to writing it to disk to improve reproducible builds
  - FIX https://github.com/mikepenz/AboutLibraries/issues/856