### PR TITLE
Replace `pritnln` in core plugin components with the `LOGGER`

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/CollectedContainer.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/CollectedContainer.kt
@@ -1,11 +1,13 @@
 package com.mikepenz.aboutlibraries.plugin.model
 
 import org.gradle.api.tasks.Input
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.Serializable
 
 data class CollectedContainer(
     // Map<Variant, Map<Identifier, Set<Versions>>>
-    @get:Input val dependencies: Map<String, Map<String, Set<String>>>
+    @get:Input val dependencies: Map<String, Map<String, Set<String>>>,
 ) : Serializable {
     /**
      * Retrieves the dependencies for a specific variant, if no variant is provided, will merge all found variants together.
@@ -13,10 +15,10 @@ data class CollectedContainer(
     fun dependenciesForVariant(variant: String? = null): Map<String, Set<String>> {
         if (variant != null) {
             return dependencies[variant] ?: run {
-                println("Variant ($variant) was missing from dependencies, this should never happen")
-                println("Available variants:")
+                LOGGER.warn("Variant ($variant) was missing from dependencies, this should never happen")
+                LOGGER.warn("Available variants:")
                 dependencies.keys.forEach {
-                    println("-- $it")
+                    LOGGER.warn("-- $it")
                 }
                 emptyMap()
             }
@@ -37,6 +39,8 @@ data class CollectedContainer(
     }
 
     companion object {
+        internal val LOGGER: Logger = LoggerFactory.getLogger(CollectedContainer::class.java)
+
         @JvmStatic
         fun from(parsed: Map<String, Map<String, List<String>>>): CollectedContainer {
             val target: MutableMap<String, MutableMap<String, Set<String>>> = mutableMapOf()

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibrariesProcessor.kt
@@ -153,7 +153,7 @@ class LibrariesProcessor(
 
         for (pattern in exclusionPatterns) {
             if (pattern.matcher(uniqueId).matches()) {
-                println("--> Skipping ${uniqueId}, matching exclusion pattern")
+                LOGGER.info("--> Skipping ${uniqueId}, matching exclusion pattern")
                 return null
             }
         }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PomLoader.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PomLoader.kt
@@ -18,7 +18,12 @@ object PomLoader {
      *
      * Logic based on: https://github.com/ben-manes/gradle-versions-plugin
      */
-    fun DependencyHandler.resolvePomFile(uniqueId: String?, id: ModuleVersionIdentifier, parent: Boolean, prefix: String = ""): File? {
+    fun DependencyHandler.resolvePomFile(
+        uniqueId: String?,
+        id: ModuleVersionIdentifier,
+        parent: Boolean,
+        prefix: String = "",
+    ): File? {
         try {
             LOGGER.debug("Attempting to resolve POM file for uniqueId={}, ModuleVersionIdentifier id={}", uniqueId, id);
             val resolutionResult = createArtifactResolutionQuery()
@@ -39,7 +44,7 @@ object PomLoader {
                     // todo identify if that ever has more than 1
                     if (artifact is ResolvedArtifactResult) {
                         if (parent) {
-                            println("${prefix}--> Retrieved POM for: $uniqueId from ${id.group}:${id.name}:${id.version}")
+                            LOGGER.info("${prefix}--> Retrieved POM for: $uniqueId from ${id.group}:${id.name}:${id.version}")
                         }
                         return artifact.file
                     }


### PR DESCRIPTION
- use LOGGER instead of `println` in core plugin components
  - FIX https://github.com/mikepenz/AboutLibraries/issues/872