### PR TITLE
Dependency Upgrades | Compose 1.4.3 / Compose-Jb 1.4.0 / Kotlin 1.8.21

### DIFF
--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -10,10 +10,10 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.mikepenz.aboutlibraries.ui.compose"
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
     buildTypes {

--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -46,6 +46,13 @@ android {
         abortOnError = false
     }
 }
+
+
+compose {
+    kotlinCompilerPlugin.set(libs.versions.composeCompilerJb.get())
+    kotlinCompilerPluginArgs.add("suppressKotlinVersionCompatibilityCheck=${libs.versions.kotlinCore.get()}")
+}
+
 kotlin {
     jvm()
 

--- a/aboutlibraries-compose/src/androidMain/AndroidManifest.xml
+++ b/aboutlibraries-compose/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.mikepenz.aboutlibraries.ui.compose" />
+<manifest />

--- a/aboutlibraries-core/build.gradle.kts
+++ b/aboutlibraries-core/build.gradle.kts
@@ -10,10 +10,10 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.mikepenz.aboutlibraries.core"
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
     buildTypes {
@@ -74,7 +74,7 @@ kotlin {
     mingwX64()
     linuxX64()
     linuxArm64()
-    // wasm32()
+    // wasm()
 
     android {
         publishAllLibraryVariants()
@@ -117,7 +117,7 @@ kotlin {
         val watchosSimulatorArm64Main by sourceSets.getting { dependsOn(iosMain) }
         val watchosX86Main by sourceSets.getting { dependsOn(iosMain) }
         val watchosX64Main by sourceSets.getting { dependsOn(iosMain) }
-        // val wasm32Main by sourceSets.creating { dependsOn(multiplatformMain) }
+        // val wasmMain by sourceSets.getting { dependsOn(multiplatformMain) }
 
         val jvmTest by getting {
             dependencies {

--- a/aboutlibraries-core/src/androidMain/AndroidManifest.xml
+++ b/aboutlibraries-core/src/androidMain/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.mikepenz.aboutlibraries.core" />
+<manifest />

--- a/aboutlibraries/build.gradle
+++ b/aboutlibraries/build.gradle
@@ -8,10 +8,11 @@ version VERSION_NAME
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInteger()
+    namespace = "com.mikepenz.aboutlibraries"
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInteger()
-        targetSdk = libs.versions.targetSdk.get().toInteger()
+
         versionName VERSION_NAME
         versionCode Integer.parseInt(VERSION_CODE)
     }

--- a/aboutlibraries/src/main/AndroidManifest.xml
+++ b/aboutlibraries/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mikepenz.aboutlibraries">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
 compose {
     kotlinCompilerPlugin.set(libs.versions.composeCompilerJb.get())
+    kotlinCompilerPluginArgs.add("suppressKotlinVersionCompatibilityCheck=${libs.versions.kotlinCore.get()}")
 }
 
 tasks.withType<JavaCompile> {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ if (getSigningFile() != null) {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInteger()
+    namespace = "com.mikepenz.aboutlibraries.sample"
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInteger()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mikepenz.aboutlibraries.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".CustomApplication"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,5 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 android.enableJetifier=false
 
 org.gradle.unsafe.configuration-cache=false
-android.disableAutomaticComponentCreation=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,17 +9,17 @@ gradleBuild = "7.4.2"
 buildTools = "33.0.2"
 # kotlin
 dokka = "1.8.10"
-kotlinCore = { require = "1.8.10" }
+kotlinCore = { require = "1.8.21" }
 kotlinCoroutines = { require = "1.6.4" }
 kotlinxSerialization = "1.5.0"
 # compose
-compose = "1.4.1"
-composeUi = "1.4.1" # foundation / materila
-composeCompiler = "1.4.4"
-composejb = "1.3.1"
-composeCompilerJb = "1.4.2"
+compose = "1.4.3"
+composeUi = "1.4.3" # foundation / material
+composeCompiler = "1.4.7"
+composejb = "1.4.0"
+composeCompilerJb = "1.4.5"
 # androidx
-activity = "1.7.0"
+activity = "1.7.1"
 cardview = "1.0.0"
 constraintLayout = "2.1.4"
 core = "1.10.0"
@@ -31,12 +31,12 @@ material = "1.8.0"
 # other
 accompanist = "0.30.1"
 fastAdapter = "5.7.0"
-gradleMvnPublish = "0.25.1"
+gradleMvnPublish = "0.25.2"
 iconics = "5.3.3"
 itemAnimators = "1.1.0"
 ivy = "2.5.1"
 materialDrawer = "9.0.1"
-okhttp = "4.10.0"
+okhttp = "4.11.0"
 
 [libraries]
 # build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- update to Gradle 8.1.1
- prepare module setup for Android Gradle Plugin 8.x
- update to Kotlin 1.8.21 
- update compose to 1.4.3
- update compose-jb to 1.4.0
- update activity to 1.7.1