### PR TITLE
Use `register` for plugin task registration

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -49,7 +49,7 @@ class AboutLibrariesPlugin : Plugin<Project> {
             }
 
             // register a global task to generate library definitions
-            project.tasks.create("exportLibraryDefinitions", AboutLibrariesTask::class.java) {
+            project.tasks.register("exportLibraryDefinitions", AboutLibrariesTask::class.java) {
                 it.description = "Writes the relevant meta data for the AboutLibraries plugin to display dependencies"
                 it.group = "Build"
                 it.variant = project.safeProp("aboutLibraries.exportVariant") ?: project.safeProp("exportVariant")


### PR DESCRIPTION
- replace `create` with `register` for `exportLibraryDefinitions`
  - FIX https://github.com/mikepenz/AboutLibraries/issues/887