### PR TITLE
Detect GPL 3.0 license without `only` component

### DIFF
--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -9,7 +9,11 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -63,7 +67,6 @@ fun LibrariesContainer(
     val libs = libraries.value?.libraries
     if (libs != null) {
         val openDialog = remember { mutableStateOf<Library?>(null) }
-
         Libraries(
             libraries = libs,
             modifier = modifier,
@@ -78,9 +81,10 @@ fun LibrariesContainer(
             itemSpacing = itemSpacing,
             header = header,
             onLibraryClick = { library ->
+                val license = library.licenses.firstOrNull()
                 if (onLibraryClick != null) {
                     onLibraryClick(library)
-                } else if (!library.licenses.firstOrNull()?.htmlReadyLicenseContent.isNullOrBlank()) {
+                } else if (!license?.htmlReadyLicenseContent.isNullOrBlank()) {
                     openDialog.value = library
                 }
             },
@@ -128,7 +132,7 @@ fun LicenseDialog(
 fun HtmlText(
     html: String,
     modifier: Modifier = Modifier,
-    color: Color = LibraryDefaults.libraryColors().contentColor
+    color: Color = LibraryDefaults.libraryColors().contentColor,
 ) {
     AndroidView(modifier = modifier, factory = { context ->
         TextView(context).apply {

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -2,15 +2,29 @@ package com.mikepenz.aboutlibraries.ui.compose
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.*
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Badge
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.Typography
+import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -37,6 +51,8 @@ fun Libraries(
     header: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
 ) {
+    val uriHandler = LocalUriHandler.current
+
     LazyColumn(
         modifier,
         verticalArrangement = Arrangement.spacedBy(itemSpacing),
@@ -52,8 +68,13 @@ fun Libraries(
             colors,
             padding,
             itemContentPadding
-        ) {
-            onLibraryClick?.invoke(it)
+        ) { library ->
+            val license = library.licenses.firstOrNull()
+            if (onLibraryClick != null) {
+                onLibraryClick.invoke(library)
+            } else if (!license?.url.isNullOrBlank()) {
+                license?.url?.also { uriHandler.openUri(it) }
+            }
         }
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -175,7 +175,6 @@ enum class SpdxLicense(
     GPL_1_0_or_later("GNU General Public License v1.0 or later", "GPL-1.0-or-later"),
     GPL_2_0_only("GNU General Public License v2.0 only", "GPL-2.0-only"),
     GPL_2_0_or_later("GNU General Public License v2.0 or later", "GPL-2.0-or-later"),
-    GPL_3_0_only("GNU General Public License v3.0 only", "GPL-3.0-only"),
     GPL_3_0_or_later("GNU General Public License v3.0 or later", "GPL-3.0-or-later"),
     gSOAP_1_3b("gSOAP Public License v1.3b", "gSOAP-1.3b"),
     HaskellReport("Haskell Language Report License", "HaskellReport"),
@@ -403,6 +402,9 @@ enum class SpdxLicense(
     }),
     JSON("JSON License", "JSON", customMatcher = { name, _ ->
         name.equals("The JSON License", true)
+    }),
+    GPL_3_0_only("GNU General Public License v3.0 only", "GPL-3.0-only", customMatcher = { name, _ ->
+        name.equals("GNU General Public License v3.0", true)
     }),
 
     // Special proprietary libraries section


### PR DESCRIPTION
- add special license matching for GPL 3.0 only
  - FIX https://github.com/mikepenz/AboutLibraries/issues/892
- fallback to opening the license url in a browser if no custom behavior is defined
  - FIX #893