### PR TITLE
Dependency Upgrades | Refactor Compose module

### DIFF
--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -71,7 +71,7 @@ compose {
 kotlin {
     jvm()
 
-    android {
+    androidTarget {
         publishLibraryVariants("release")
     }
 

--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -2,31 +2,24 @@ package com.mikepenz.aboutlibraries.ui.compose
 
 import android.content.Context
 import android.widget.TextView
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
 import com.mikepenz.aboutlibraries.Libs
-import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.data.fakeData
 import com.mikepenz.aboutlibraries.ui.compose.util.StableLibrary
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
@@ -41,11 +34,11 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibrariesContainer(
     modifier: Modifier = Modifier,
-    lazyListState: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(0.dp),
     librariesBlock: (Context) -> Libs = { context ->
         Libs.Builder().withContext(context).build()
     },
+    lazyListState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
@@ -54,80 +47,35 @@ fun LibrariesContainer(
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
     itemSpacing: Dp = LibraryDefaults.LibraryItemSpacing,
     header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
+    onLibraryClick: ((StableLibrary) -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
 
     val libraries = produceState<Libs?>(null) {
         value = withContext(Dispatchers.IO) {
             librariesBlock(context)
         }
     }
-
-    val libs = libraries.value?.libraries?.stable
-    if (libs != null) {
-        val openDialog = remember { mutableStateOf<Library?>(null) }
-        Libraries(
-            libraries = libs,
-            modifier = modifier,
-            lazyListState = lazyListState,
-            contentPadding = contentPadding,
-            showAuthor = showAuthor,
-            showVersion = showVersion,
-            showLicenseBadges = showLicenseBadges,
-            colors = colors,
-            padding = padding,
-            itemContentPadding = itemContentPadding,
-            itemSpacing = itemSpacing,
-            header = header,
-            onLibraryClick = { library ->
-                val license = library.licenses.firstOrNull()
-                if (onLibraryClick != null) {
-                    onLibraryClick(library)
-                } else if (!license?.htmlReadyLicenseContent.isNullOrBlank()) {
-                    openDialog.value = library
-                } else if (!license?.url.isNullOrBlank()) {
-                    license?.url?.also { uriHandler.openUri(it) }
-                }
-            },
-        )
-
-        val library = openDialog.value
-        if (library != null) {
-            LicenseDialog(library = library.stable, colors) {
-                openDialog.value = null
-            }
+    LibrariesContainer(
+        libraries.value?.stable,
+        modifier,
+        lazyListState,
+        contentPadding,
+        showAuthor,
+        showVersion,
+        showLicenseBadges,
+        colors,
+        padding,
+        itemContentPadding,
+        itemSpacing,
+        header,
+        onLibraryClick,
+        licenseDialogBody = { library ->
+            HtmlText(
+                html = library.library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty(),
+                color = colors.contentColor,
+            )
         }
-    }
-}
-
-@Composable
-fun LicenseDialog(
-    library: StableLibrary,
-    colors: LibraryColors = LibraryDefaults.libraryColors(),
-    onDismiss: () -> Unit,
-) {
-    val scrollState = rememberScrollState()
-    AlertDialog(
-        backgroundColor = colors.backgroundColor,
-        contentColor = colors.contentColor,
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(id = android.R.string.ok))
-            }
-        },
-        text = {
-            Column(
-                modifier = Modifier.verticalScroll(scrollState),
-            ) {
-                HtmlText(
-                    html = library.library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty(),
-                    color = colors.contentColor,
-                )
-            }
-        },
     )
 }
 

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.Stable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -16,10 +16,117 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.util.StableLibrary
+import com.mikepenz.aboutlibraries.ui.compose.util.StableLibs
 import com.mikepenz.aboutlibraries.ui.compose.util.author
+import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import kotlinx.collections.immutable.ImmutableList
+
+
+/**
+ * Displays all provided libraries in a simple list.
+ */
+@Composable
+fun LibrariesContainer(
+    libraries: StableLibs?,
+    modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    showAuthor: Boolean = true,
+    showVersion: Boolean = true,
+    showLicenseBadges: Boolean = true,
+    colors: LibraryColors = LibraryDefaults.libraryColors(),
+    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
+    itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
+    itemSpacing: Dp = LibraryDefaults.LibraryItemSpacing,
+    header: (LazyListScope.() -> Unit)? = null,
+    onLibraryClick: ((StableLibrary) -> Unit)? = null,
+    licenseDialogBody: (@Composable (StableLibrary) -> Unit)? = null,
+    licenseDialogConfirmText: String = "OK",
+) {
+    val uriHandler = LocalUriHandler.current
+
+    val libs = libraries?.libraries
+    if (libs != null) {
+        val openDialog = remember { mutableStateOf<StableLibrary?>(null) }
+
+        Libraries(
+            libraries = libs,
+            modifier = modifier,
+            lazyListState = lazyListState,
+            contentPadding = contentPadding,
+            showAuthor = showAuthor,
+            showVersion = showVersion,
+            showLicenseBadges = showLicenseBadges,
+            colors = colors,
+            padding = padding,
+            itemContentPadding = itemContentPadding,
+            itemSpacing = itemSpacing,
+            header = header,
+            onLibraryClick = { library ->
+                val license = library.library.licenses.firstOrNull()
+                if (onLibraryClick != null) {
+                    onLibraryClick(library)
+                } else if (!license?.htmlReadyLicenseContent.isNullOrBlank()) {
+                    openDialog.value = library
+                } else if (!license?.url.isNullOrBlank()) {
+                    license?.url?.also { uriHandler.openUri(it) }
+                }
+            },
+        )
+
+        val library = openDialog.value
+        if (library != null && licenseDialogBody != null) {
+            LicenseDialog(library, colors, licenseDialogConfirmText, body = licenseDialogBody) {
+                openDialog.value = null
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun LicenseDialog(
+    library: StableLibrary,
+    colors: LibraryColors = LibraryDefaults.libraryColors(),
+    confirmText: String = "OK",
+    body: @Composable (StableLibrary) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(),
+        content = {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                color = colors.backgroundColor,
+                contentColor = colors.contentColor
+            ) {
+                Column {
+                    FlowRow(
+                        modifier = Modifier.verticalScroll(scrollState).padding(8.dp).weight(1f)
+                    ) {
+                        body(library)
+                    }
+                    FlowRow(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(horizontal = 8.dp, vertical = 2.dp)
+                    ) {
+                        TextButton(onClick = onDismiss) {
+                            Text(confirmText)
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
 
 /**
  * Displays all provided libraries in a simple list.
@@ -38,7 +145,7 @@ fun Libraries(
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
     itemSpacing: Dp = LibraryDefaults.LibraryItemSpacing,
     header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
+    onLibraryClick: ((StableLibrary) -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -58,7 +165,7 @@ fun Libraries(
             padding,
             itemContentPadding
         ) { library ->
-            val license = library.licenses.firstOrNull()
+            val license = library.library.licenses.firstOrNull()
             if (onLibraryClick != null) {
                 onLibraryClick.invoke(library)
             } else if (!license?.url.isNullOrBlank()) {
@@ -76,7 +183,7 @@ internal inline fun LazyListScope.libraryItems(
     colors: LibraryColors,
     padding: LibraryPadding,
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
-    crossinline onLibraryClick: ((Library) -> Unit),
+    crossinline onLibraryClick: ((StableLibrary) -> Unit),
 ) {
     items(libraries) { library ->
         Library(
@@ -88,7 +195,7 @@ internal inline fun LazyListScope.libraryItems(
             padding,
             itemContentPadding
         ) {
-            onLibraryClick.invoke(library.library)
+            onLibraryClick.invoke(library)
         }
     }
 }

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/util/Extensions.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/util/Extensions.kt
@@ -1,9 +1,13 @@
 package com.mikepenz.aboutlibraries.ui.compose.util
 
 import androidx.compose.runtime.Immutable
+import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.entity.License
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
 import kotlin.jvm.JvmInline
 
 @JvmInline
@@ -13,6 +17,19 @@ value class StableLibrary(val library: Library)
 val Library.stable get() = StableLibrary(this)
 
 val List<Library>.stable get() = map { it.stable }.toImmutableList()
+
+@JvmInline
+@Immutable
+value class StableLicense(val license: License)
+
+val License.stable get() = StableLicense(this)
+
+val Set<License>.stable get() = map { it.stable }.toImmutableSet()
+
+@Immutable
+class StableLibs(val libraries: ImmutableList<StableLibrary>, val licenses: ImmutableSet<StableLicense>)
+
+val Libs.stable get() = StableLibs(this.libraries.stable, this.licenses.stable)
 
 val Library.author: String
     get() = developers.takeIf { it.isNotEmpty() }?.map { it.name }?.joinToString(", ") ?: organization?.name ?: ""

--- a/aboutlibraries-compose/src/nonAndroidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose/src/nonAndroidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -4,16 +4,14 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
-import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.util.StableLibrary
 import com.mikepenz.aboutlibraries.ui.compose.util.stable
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
  * Displays all provided libraries in a simple list.
@@ -32,10 +30,11 @@ fun LibrariesContainer(
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
     itemSpacing: Dp = LibraryDefaults.LibraryItemSpacing,
     header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
+    onLibraryClick: ((StableLibrary) -> Unit)? = null,
 ) {
+    val libs = Libs.Builder().withJson(aboutLibsJson).build().stable
     LibrariesContainer(
-        { Libs.Builder().withJson(aboutLibsJson).build() },
+        libs,
         modifier = modifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
@@ -47,7 +46,10 @@ fun LibrariesContainer(
         itemContentPadding = itemContentPadding,
         itemSpacing = itemSpacing,
         header = header,
-        onLibraryClick = onLibraryClick
+        onLibraryClick = onLibraryClick,
+        licenseDialogBody = { library ->
+            Text(library.library.licenses.firstOrNull()?.licenseContent ?: "")
+        }
     )
 }
 
@@ -68,30 +70,27 @@ fun LibrariesContainer(
     itemContentPadding: PaddingValues = LibraryDefaults.ContentPadding,
     itemSpacing: Dp = LibraryDefaults.LibraryItemSpacing,
     header: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
+    onLibraryClick: ((StableLibrary) -> Unit)? = null,
 ) {
-    val libraries = produceState<Libs?>(null) {
-        value = withContext(Dispatchers.Default) {
-            librariesBlock()
-        }
-    }
+    val libs = librariesBlock().stable
 
-    val libs = libraries.value?.libraries?.stable
-    if (libs != null) {
-        Libraries(
-            libraries = libs,
-            modifier = modifier,
-            lazyListState = lazyListState,
-            contentPadding = contentPadding,
-            showAuthor = showAuthor,
-            showVersion = showVersion,
-            showLicenseBadges = showLicenseBadges,
-            colors = colors,
-            padding = padding,
-            itemContentPadding = itemContentPadding,
-            itemSpacing = itemSpacing,
-            header = header,
-            onLibraryClick = onLibraryClick
-        )
-    }
+    LibrariesContainer(
+        libs,
+        modifier,
+        lazyListState,
+        contentPadding,
+        showAuthor,
+        showVersion,
+        showLicenseBadges,
+        colors,
+        padding,
+        itemContentPadding,
+        itemSpacing,
+        header,
+        onLibraryClick,
+        licenseDialogBody = { library ->
+            Text(library.library.licenses.firstOrNull()?.licenseContent ?: "")
+        }
+    )
+
 }

--- a/aboutlibraries-core/build.gradle.kts
+++ b/aboutlibraries-core/build.gradle.kts
@@ -73,7 +73,7 @@ kotlin {
     linuxArm64()
     // wasm()
 
-    android {
+    androidTarget {
         publishAllLibraryVariants()
     }
 
@@ -127,6 +127,7 @@ kotlin {
 dependencies {
     // kotlinx Serialize
     "multiplatformMainImplementation"(libs.kotlinx.serialization)
+
 }
 
 tasks.dokkaHtml.configure {

--- a/aboutlibraries-core/build.gradle.kts
+++ b/aboutlibraries-core/build.gradle.kts
@@ -38,7 +38,6 @@ android {
 
 kotlin {
     jvm()
-
     js(IR) {
         nodejs {}
         browser {}
@@ -50,32 +49,41 @@ kotlin {
             }
         }
     }
-
-    ios()
-    iosX64()
-    iosArm32()
-    iosArm64()
-    iosSimulatorArm64()
-    tvos()
-    tvosX64()
-    tvosArm64()
-    tvosSimulatorArm64()
-    watchos()
-    watchosX86()
-    watchosX64()
-    watchosArm32()
-    watchosArm64()
-    watchosSimulatorArm64()
-    macosX64()
-    macosArm64()
-    mingwX64()
-    linuxX64()
-    linuxArm64()
-    // wasm()
-
     androidTarget {
         publishAllLibraryVariants()
     }
+    // wasm()
+
+    // tier 1
+    linuxX64()
+    macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    // tier 2
+    linuxArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    iosArm64()
+
+    // tier 3
+    // androidNativeArm32()
+    // androidNativeArm64()
+    // androidNativeX86()
+    // androidNativeX64()
+    mingwX64()
+    watchosDeviceArm64()
+
+    // common sets
+    ios()
+    tvos()
+    watchos()
 
     /*
     cocoapods {
@@ -102,7 +110,6 @@ kotlin {
         val macosArm64Main by sourceSets.getting { dependsOn(desktopMain) }
         val linuxArm64Main by sourceSets.getting { dependsOn(desktopMain) }
         val iosMain by sourceSets.getting { dependsOn(multiplatformMain) }
-        val iosArm32Main by sourceSets.getting { dependsOn(iosMain) }
         val iosArm64Main by sourceSets.getting { dependsOn(iosMain) }
         val iosSimulatorArm64Main by sourceSets.getting { dependsOn(iosMain) }
         val iosX64Main by sourceSets.getting { dependsOn(iosMain) }
@@ -112,8 +119,8 @@ kotlin {
         val watchosArm32Main by sourceSets.getting { dependsOn(iosMain) }
         val watchosArm64Main by sourceSets.getting { dependsOn(iosMain) }
         val watchosSimulatorArm64Main by sourceSets.getting { dependsOn(iosMain) }
-        val watchosX86Main by sourceSets.getting { dependsOn(iosMain) }
         val watchosX64Main by sourceSets.getting { dependsOn(iosMain) }
+        val watchosDeviceArm64Main by sourceSets.getting { dependsOn(iosMain) }
         // val wasmMain by sourceSets.getting { dependsOn(multiplatformMain) }
 
         val jvmTest by getting {

--- a/app-desktop/src/main/kotlin/main.kt
+++ b/app-desktop/src/main/kotlin/main.kt
@@ -1,19 +1,12 @@
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.useResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
-import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 
 fun main() = application {
     Window(title = "AboutLibraries Sample", onCloseRequest = ::exitApplication) {
@@ -21,35 +14,9 @@ fun main() = application {
             Scaffold(
                 topBar = { TopAppBar(title = { Text("AboutLibraries Compose Desktop Sample") }) }
             ) {
-                val openDialog = remember { mutableStateOf<String?>(null) }
-
                 LibrariesContainer(useResource("aboutlibraries.json") {
                     it.bufferedReader().readText()
-                }, Modifier.fillMaxSize()) {
-                    openDialog.value = it.licenses.firstOrNull()?.strippedLicenseContent ?: ""
-                }
-
-                if (!openDialog.value.isNullOrBlank()) {
-                    val scrollState = rememberScrollState()
-                    Surface(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .verticalScroll(scrollState)
-                            .fillMaxSize()
-                    ) {
-                        Column(modifier = Modifier.padding(8.dp)) {
-                            Text(
-                                text = openDialog.value ?: "",
-                            )
-                            TextButton(
-                                onClick = { openDialog.value = null },
-                                modifier = Modifier.align(Alignment.End)
-                            ) {
-                                Text("OK")
-                            }
-                        }
-                    }
-                }
+                }, Modifier.fillMaxSize())
             }
         }
     }

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/ComposeActivity.kt
@@ -59,9 +59,11 @@ fun MainLayout() {
                 TopAppBar(
                     title = { Text("Compose Sample") },
                     backgroundColor = MaterialTheme.colors.surface.copy(alpha = 0.9f),
-                    modifier = Modifier.fillMaxWidth().padding(
-                        WindowInsets.statusBars.asPaddingValues()
-                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            WindowInsets.statusBars.asPaddingValues()
+                        ),
                     actions = {
                         IconButton(onClick = {
                             showAuthor = !showAuthor
@@ -83,7 +85,7 @@ fun MainLayout() {
             },
         ) { contentPadding ->
             LibrariesContainer(
-                Modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(top = contentPadding.calculateTopPadding()),
                 contentPadding = WindowInsets.navigationBars.asPaddingValues(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,5 @@ android.enableJetifier=false
 org.gradle.unsafe.configuration-cache=false
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
+
+android.suppressUnsupportedCompileSdk=34

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,10 +14,10 @@ kotlinCoroutines = { require = "1.7.3" }
 kotlinxSerialization = "1.5.1"
 kotlinxCollections = "0.3.5"
 # compose
-compose = "1.5.0-rc01"
-composeUi = "1.5.0-rc01" # foundation / material
+compose = "1.5.0"
+composeUi = "1.5.0" # foundation / material
 composeCompiler = "1.5.1"
-composejb = "1.5.0-dev1136" # "1.4.0-dev-wasm09" # "1.5.0-dev1114"
+composejb = "1.5.0-beta02" # "1.4.0-dev-wasm09" # "1.5.0-dev1114"
 composeCompilerJb = "1.5.0"
 # androidx
 activity = "1.7.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,16 +9,16 @@ gradleBuild = "8.0.2"
 buildTools = "34.0.0"
 # kotlin
 dokka = "1.8.20"
-kotlinCore = { require = "1.8.22" }
-kotlinCoroutines = { require = "1.7.2" }
+kotlinCore = { require = "1.9.0" }
+kotlinCoroutines = { require = "1.7.3" }
 kotlinxSerialization = "1.5.1"
 kotlinxCollections = "0.3.5"
 # compose
-compose = "1.4.3"
-composeUi = "1.4.3" # foundation / material
-composeCompiler = "1.4.8"
-composejb = "1.4.1"
-composeCompilerJb = "1.4.8"
+compose = "1.5.0-rc01"
+composeUi = "1.5.0-rc01" # foundation / material
+composeCompiler = "1.5.1"
+composejb = "1.5.0-dev1136" # "1.4.0-dev-wasm09" # "1.5.0-dev1114"
+composeCompilerJb = "1.5.0"
 # androidx
 activity = "1.7.2"
 cardview = "1.0.0"
@@ -26,7 +26,7 @@ constraintLayout = "2.1.4"
 core = "1.10.1"
 lifecycle = { require = "2.6.1" }
 navigation = "2.6.0"
-recyclerView = "1.3.0"
+recyclerView = "1.3.1"
 # google
 material = "1.9.0"
 # other

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 # android sdk versions
-compileSdk = "33"
+compileSdk = "34"
 coreMinSdk = "19"
 minSdk = "21"
-targetSdk = "33"
+targetSdk = "34"
 # build
 gradleBuild = "8.0.2"
 buildTools = "34.0.0"


### PR DESCRIPTION
- update to the latest libraries 
```
  - kotlin 1.9
  - coroutines 1.7.3
  - compose = "1.5.0-rc01"
  - composeUi = "1.5.0-rc01" # foundation / material
  - composeCompiler = "1.5.1"
  - composejb = "1.5.0-dev1136" # "1.4.0-dev-wasm09" # "1.5.0-dev1114"
  - composeCompilerJb = "1.5.0"
  - recyclerView = "1.3.1"
```
- upgrade to compile sdk 34
- move Dialog to common source set 
- further upgrade dependencies
- refactor some of the core definitions
- drop deprecated platform architectures