### PR TITLE
Fix CI for releases on macOS-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           ./gradlew publishPlugins | true
 
       - name: Publish the macOS artifacts
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-14'
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
- use the proper runner for publishing releases
  - FIX https://github.com/mikepenz/AboutLibraries/issues/959