### PR TITLE
Library Serializer

### DIFF
--- a/aboutlibraries-core/build.gradle.kts
+++ b/aboutlibraries-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish")
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 android {

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Developer.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Developer.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.entity
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Describes the [Developer] defined in the `pom.xml` file.
  *
@@ -8,7 +11,8 @@ package com.mikepenz.aboutlibraries.entity
  * @param name of the developer
  * @param organisationUrl optional organisation url for the developer
  */
+@Serializable
 data class Developer(
-    val name: String?,
-    val organisationUrl: String?
+    @SerialName("name") val name: String?,
+    @SerialName("organisationUrl") val organisationUrl: String?
 )

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Funding.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Funding.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.entity
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Describes the [Funding] as defined by the dependency.
  * This is only supported for projects hosted for dependencies hosted on: https://github.com/mikepenz/AboutLibraries#special-repository-support
@@ -8,7 +11,8 @@ package com.mikepenz.aboutlibraries.entity
  * @param platform name of the platform allowing to fund the project
  * @param url url pointing towards the location to fund the project
  */
+@Serializable
 data class Funding(
-    val platform: String,
-    val url: String
+    @SerialName("platform") val platform: String,
+    @SerialName("url") val url: String
 )

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Library.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Library.kt
@@ -3,6 +3,8 @@ package com.mikepenz.aboutlibraries.entity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Describes a complete [Library] element, specifying important information about a used dependency.
@@ -18,18 +20,19 @@ import kotlinx.collections.immutable.persistentSetOf
  * @param licenses all identified licenses for this artifact
  * @param funding all identified funding opportunities for this artifact
  */
+@Serializable
 data class Library(
-    val uniqueId: String,
-    val artifactVersion: String?,
-    val name: String,
-    val description: String?,
-    val website: String?,
-    val developers: ImmutableList<Developer>,
-    val organization: Organization?,
-    val scm: Scm?,
-    val licenses: ImmutableSet<License> = persistentSetOf(),
-    val funding: ImmutableSet<Funding> = persistentSetOf(),
-    val tag: String? = null,
+    @SerialName("uniqueId") val uniqueId: String,
+    @SerialName("artifactVersion") val artifactVersion: String?,
+    @SerialName("name") val name: String,
+    @SerialName("description") val description: String?,
+    @SerialName("website") val website: String?,
+    @SerialName("developers") val developers: ImmutableList<Developer>,
+    @SerialName("organization") val organization: Organization?,
+    @SerialName("scm") val scm: Scm?,
+    @SerialName("licenses") val licenses: ImmutableSet<License> = persistentSetOf(),
+    @SerialName("funding") val funding: ImmutableSet<Funding> = persistentSetOf(),
+    @SerialName("tag") val tag: String? = null,
 ) {
     /**
      * defines the [uniqueId]:[artifactVersion] combined

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/License.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/License.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.entity
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Describes a complete [License] element.
  * Either retrieved from spdx or downloaded from the artifacts repo
@@ -11,13 +14,14 @@ package com.mikepenz.aboutlibraries.entity
  * @param licenseContent contains the whole license content as downloaded from the server
  * @param hash usually calculated to identify if a license is re-used and can be used for multiple artifacts
  */
+@Serializable
 data class License(
-    val name: String,
-    val url: String?,
-    val year: String? = null,
-    val spdxId: String? = null,
-    val licenseContent: String? = null,
-    val hash: String
+    @SerialName("name") val name: String,
+    @SerialName("url") val url: String?,
+    @SerialName("year") val year: String? = null,
+    @SerialName("spdxId") val spdxId: String? = null,
+    @SerialName("licenseContent") val licenseContent: String? = null,
+    @SerialName("hash") val hash: String
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.entity
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Describes the [Organization] defined in the `pom.xml` file.
  *
@@ -8,7 +11,8 @@ package com.mikepenz.aboutlibraries.entity
  * @param name of the organisation
  * @param url optional url to the website of the defined organisation
  */
+@Serializable
 data class Organization(
-    val name: String,
-    val url: String?
+    @SerialName("name") val name: String,
+    @SerialName("url") val url: String?
 )

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Scm.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Scm.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.entity
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Describes the [Scm] defined in the `pom.xml` file.
  *
@@ -9,8 +12,9 @@ package com.mikepenz.aboutlibraries.entity
  * @param developerConnection optionally describing the developer connection
  * @param url optionally linking to the hosted form of this artifact
  */
+@Serializable
 data class Scm(
-    val connection: String?,
-    val developerConnection: String?,
-    val url: String?
+    @SerialName("connection") val connection: String?,
+    @SerialName("developerConnection") val developerConnection: String?,
+    @SerialName("url") val url: String?
 )


### PR DESCRIPTION
Mark `Library` and Subclasses as `Serializable` to auto-generate a serializer.

This is useful as many Compose libraries, frameworks and methods require some kind of state saving (e.g. Decompose) and `kotlin-serialization` is the recommended way to be compatible with K2.

**Additionally:** this brings the core module a step closer to go fully multiplatform and get rid of platform dependend Parser