### PR TITLE
Set onclick listener of SimpleLibraryItem to null if no license is known

### DIFF
--- a/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/item/SimpleLibraryItem.kt
+++ b/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/item/SimpleLibraryItem.kt
@@ -64,6 +64,8 @@ class SimpleLibraryItem(internal val library: Library, private val libsBuilder: 
                     openLicense(ctx, libsBuilder, library)
                 }
             }
+        } else {
+            holder.itemView.setOnClickListener(null)
         }
     }
 


### PR DESCRIPTION
Previously, tapping on a library for which no license is known would pop up a dialog with the license of whatever library was previously bound to the view holder.