### PR TITLE
Fix CollectorTask output to be dependent on project name [Plugin]

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesCollectorTask.kt
@@ -3,7 +3,12 @@ package com.mikepenz.aboutlibraries.plugin
 import com.mikepenz.aboutlibraries.plugin.model.CollectedContainer
 import com.mikepenz.aboutlibraries.plugin.util.DependencyCollector
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.slf4j.LoggerFactory
 import java.io.File
 
 @CacheableTask
@@ -11,6 +16,9 @@ abstract class AboutLibrariesCollectorTask : DefaultTask() {
 
     @Internal
     protected val extension = project.extensions.getByName("aboutLibraries") as AboutLibrariesExtension
+
+    @Input
+    val projectName = project.name
 
     @Input
     val includePlatform = extension.includePlatform
@@ -37,9 +45,14 @@ abstract class AboutLibrariesCollectorTask : DefaultTask() {
 
     @TaskAction
     fun action() {
+        LOGGER.info("Collecting for: $projectName")
         if (!::collectedDependencies.isInitialized) {
             configure()
         }
         dependencyCache.writeText(groovy.json.JsonOutput.toJson(collectedDependencies))
+    }
+
+    private companion object {
+        private val LOGGER = LoggerFactory.getLogger(AboutLibrariesCollectorTask::class.java)!!
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -69,9 +69,9 @@ class AboutLibrariesPlugin : Plugin<Project> {
 
     private val Project.experimentalCache: Boolean
         get() = hasProperty("org.gradle.unsafe.configuration-cache") &&
-                property("org.gradle.unsafe.configuration-cache") == "true" ||
-                hasProperty("org.gradle.configuration-cache") &&
-                property("org.gradle.configuration-cache") == "true"
+            property("org.gradle.unsafe.configuration-cache") == "true" ||
+            hasProperty("org.gradle.configuration-cache") &&
+            property("org.gradle.configuration-cache") == "true"
 
 
     companion object {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/GitHubApi.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/GitHubApi.kt
@@ -13,7 +13,7 @@ import java.io.OutputStreamWriter
 import java.net.URL
 
 internal class GitHubApi(
-    private val gitHubToken: String? = null
+    private val gitHubToken: String? = null,
 ) : IApi {
     private var rateLimit: Int = 0
 
@@ -36,7 +36,7 @@ internal class GitHubApi(
             }
             limit
         } catch (t: Throwable) {
-            LOGGER.error("Could not retrieve `rate_limit`. Please check if the token is provided.")
+            LOGGER.error("Could not retrieve `rate_limit`. Please check if the token is provided. (${t.message})")
             0
         }
     }


### PR DESCRIPTION
- ensure the `project-name` (module name) is also used for caching the collector task output
  - not doing so might result in the same dependencies for 2 individual modules