### PR TITLE
Reduce noise of AmbiguousArtifactVariantsException logs even more

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -130,10 +130,13 @@ class DependencyCollector(
                         }
                     }
                 } catch (e: Throwable) {
-                    if (LOGGER.isDebugEnabled) {
-                        LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency - ${e.message}")
-                    } else {
-                        LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency", e)
+                    when {
+                        LOGGER.isDebugEnabled -> {
+                            LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency", e)
+                        }
+                        LOGGER.isInfoEnabled -> {
+                            LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Follow-up to #955 and #956

## Summary

Even after the the latest changes in #956, our code base is still flooded/spammed by the `AmbiguousArtifactVariantsException` logs.  

We have a quite large amount of flavor dimensions with 4 different flavors. This many flavors probably causes more cluttering logs than in many other code bases. So we are especially affect.

Therefore I'd like to propose to reduce the log noise even more.

## Background

### `AmbiguousArtifactVariantsException` Insights

The content of the `AmbiguousArtifactVariantsException` `message` is the following:
```
The consumer was configured to find a library for use during runtime, preferably optimized for Android, as well as attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '8.4.0', attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug', attribute 'com.android.build.api.attributes.ProductFlavor:appType' with value 'standalone', attribute 'com.android.build.api.attributes.ProductFlavor:endpoint' with value 'dev', attribute 'com.android.build.api.attributes.ProductFlavor:platform' with value 'androidtv', attribute 'com.android.build.api.attributes.ProductFlavor:tenant' [...]
  [...]
  - Configuration
  [...]
  - Configuration ':core:tenantADebugRuntimeElements' variant supported-locale-list declares a library for use during runtime, preferably optimized for Android, as well as attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '8.4.0', attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug', attribute 'com.android.build.api.attributes.ProductFlavor:tenant' with value 'tenantA', attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm':
      - Unmatched attributes:
          - Doesn't say anything about com.android.build.api.attributes.ProductFlavor:appType (required 'standalone')
          - Doesn't say anything about com.android.build.api.attributes.ProductFlavor:endpoint (required 'dev')
          - Doesn't say anything about com.android.build.api.attributes.ProductFlavor:platform (required 'androidtv')
          - Provides attribute 'artifactType' with value 'supported-locale-list' but the consumer didn't ask for it
          - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'tenantADebug' but the consumer didn't ask for it
          - Provides attribute 'tenant' with value 'tenantA' but the consumer didn't ask for it
```

So printing "only" the `message` of this `AmbiguousArtifactVariantsException` exception is already adding a lot of noise to the Gradle logs. 
The `message` alone can take up to 157 lines when using four Android flavor dimensions. And this exception is thrown multiple times. In the case of four flavor dimensions 30 times (30*157=4710 lines).

### The current `isDebugEnabled` condition is seemingly inverted
Printing the exception stacktrace for non-debug logs is likely unwanted and "only" the `message` for debug log.

### The `isDebugEnabled`  else condition is currently always printed
`LOGGER.warn` is always printed (because `isWarnEnabled` is always `true`). Therefore the (expected) `AmbiguousArtifactVariantsException` exception is always logged.

### Plugin Users Point Of View
`AmbiguousArtifactVariantsException` is for the plugin consumers not actionable at the moment. So any details about it is not adding value, but only clutters the users log output.


## Pull Request Changes

With the insights from above this Change Request disables by default any output of the `AmbiguousArtifactVariantsException` exception. It is not actionable for the plugin users and therefore should not be shown by default.

Slightly more information can be requested via the Gradle `--info` CLI parameter (`isInfoEnabled`) where only the an hint is printed, that there's an ambiguity in the resolved config, and *no* further details.

Debugging information can be requsted via Gradle `--debug` CLI parameter (`isDebugEnabled`) which provides the complete exception with all the details.