### PR TITLE
Fix Library badge cutoff

### DIFF
--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -237,6 +237,7 @@ internal inline fun LazyListScope.libraryItems(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun Library(
     library: Library,
@@ -290,7 +291,7 @@ internal fun Library(
             )
         }
         if (showLicenseBadges && library.licenses.isNotEmpty()) {
-            Row {
+            FlowRow {
                 library.licenses.forEach {
                     Badge(
                         modifier = Modifier.padding(padding.badgePadding),

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -238,7 +238,7 @@ internal inline fun LazyListScope.libraryItems(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 internal fun Library(
     library: Library,
@@ -292,7 +292,7 @@ internal fun Library(
             )
         }
         if (showLicenseBadges && library.licenses.isNotEmpty()) {
-            Row {
+            FlowRow {
                 library.licenses.forEach {
                     Badge(
                         modifier = Modifier.padding(padding.badgePadding),


### PR DESCRIPTION
I fixed the issue of badge clipping by using `FlowRow` instead of **Row**. Since the text can be long or there can be multiple badges, I changed Row to FlowRow without implementing scroll or other handling.

- before
<img width="327" alt="스크린샷 2024-06-23 오후 8 25 33" src="https://github.com/mikepenz/AboutLibraries/assets/27290999/7da94b5b-861c-40b1-91a0-0553e05025d9">
<image width="280" src="https://github.com/mikepenz/AboutLibraries/assets/27290999/c0bb7ed3-329b-4cf8-baaf-4c77efe1a4de">

- after
<image width="280" src="https://github.com/mikepenz/AboutLibraries/assets/27290999/06e7310c-61fd-4269-8739-3c353cf25f09">


