### PR TITLE
Apply `excludeFields` only to fields in `Library`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ aboutLibraries {
     // Full license text for license IDs mentioned here will be included, even if no detected dependency uses them.
     additionalLicenses = ["mit", "mpl_2_0"]
     // Allows to exclude some fields from the generated meta data field.
-    excludeFields = ["developers", "funding"]
+    // If the class name is specified, the field is only excluded for that class; without a class name, the exclusion is global.
+    excludeFields = ["License.name", "developers", "funding"]
     // Enable inclusion of `platform` dependencies in the library report
     includePlatform = true
     // Define the strict mode, will fail if the project uses licenses not allowed

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -219,10 +219,14 @@ abstract class AboutLibrariesExtension {
     /**
      * Defines fields which will be excluded during the serialisation of the metadata output file.
      *
-     * Any field as included in the [com.mikepenz.aboutlibraries.plugin.mapping.Library] can theoretically be excluded.
+     * It is possible to qualify the field names by specifying the class name (e.g. "License.name").
+     * Permissible qualifiers are "ResultContainer", "Library", "Developer", "Organization", "Funding", "Scm",
+     * "License" and "MetaData".
+     * Unqualified field names (e.g. "description") are applied to the entire output.
+     *
      * ```
      * aboutLibraries {
-     *   excludeFields = arrayOf("description", "tag")
+     *   excludeFields = arrayOf("License.name", "ResultContainer.metadata", "description", "tag")
      * }
      * ```
      */

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
@@ -2,6 +2,7 @@ package com.mikepenz.aboutlibraries.plugin.model
 
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
+import com.mikepenz.aboutlibraries.plugin.util.PartialObjectConverter
 import groovy.json.JsonGenerator
 import groovy.json.JsonOutput
 import java.io.File
@@ -29,7 +30,8 @@ fun ResultContainer.writeToDisk(outputFile: File, excludeFields: Array<String>, 
     val fieldNames = mutableListOf("artifactId", "groupId", "artifactFolder").also {
         it.addAll(excludeFields)
     }
-    val jsonGenerator = JsonGenerator.Options().excludeNulls().excludeFieldsByName(fieldNames).build()
+    val libraryConverter = PartialObjectConverter(Library::class.java, fieldNames)
+    val jsonGenerator = JsonGenerator.Options().excludeNulls().addConverter(libraryConverter).build()
     PrintWriter(OutputStreamWriter(outputFile.outputStream(), StandardCharsets.UTF_8), true).use {
         it.write(jsonGenerator.toJson(this).let { json -> if (prettyPrint) JsonOutput.prettyPrint(json) else json })
     }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
@@ -1,7 +1,11 @@
 package com.mikepenz.aboutlibraries.plugin.model
 
+import com.mikepenz.aboutlibraries.plugin.mapping.Developer
+import com.mikepenz.aboutlibraries.plugin.mapping.Funding
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
+import com.mikepenz.aboutlibraries.plugin.mapping.Organization
+import com.mikepenz.aboutlibraries.plugin.mapping.Scm
 import com.mikepenz.aboutlibraries.plugin.util.PartialObjectConverter
 import groovy.json.JsonGenerator
 import groovy.json.JsonOutput
@@ -27,14 +31,25 @@ class MetaData(
 )
 
 fun ResultContainer.writeToDisk(outputFile: File, excludeFields: Array<String>, prettyPrint: Boolean) {
+    val allowedQualifiers = setOf(
+        ResultContainer::class.simpleName,
+        Library::class.simpleName,
+        Developer::class.simpleName,
+        Organization::class.simpleName,
+        Funding::class.simpleName,
+        Scm::class.simpleName,
+        License::class.simpleName,
+        MetaData::class.simpleName,
+    )
     val qualifiedFieldNames = mutableSetOf(
-        "${Library::class.qualifiedName}.${Library::artifactId.name}",
-        "${Library::class.qualifiedName}.${Library::groupId.name}",
-        "${Library::class.qualifiedName}.${Library::artifactFolder.name}"
+        "${Library::class.simpleName}.${Library::artifactId.name}",
+        "${Library::class.simpleName}.${Library::groupId.name}",
+        "${Library::class.simpleName}.${Library::artifactFolder.name}"
     )
     val unqualifiedFieldNames = mutableSetOf<String>()
     excludeFields.forEach { excludedField ->
-        if (excludedField.startsWith("com.mikepenz.aboutlibraries.plugin")) {
+        val segments = excludedField.split(".")
+        if (segments.size == 2 && allowedQualifiers.contains(segments.first())) {
             qualifiedFieldNames.add(excludedField)
         } else {
             unqualifiedFieldNames.add(excludedField)

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/model/ResultContainer.kt
@@ -31,7 +31,7 @@ class MetaData(
 )
 
 fun ResultContainer.writeToDisk(outputFile: File, excludeFields: Array<String>, prettyPrint: Boolean) {
-    val allowedQualifiers = setOf(
+    val allowedExclusionQualifiers = setOf(
         ResultContainer::class.simpleName,
         Library::class.simpleName,
         Developer::class.simpleName,
@@ -41,24 +41,24 @@ fun ResultContainer.writeToDisk(outputFile: File, excludeFields: Array<String>, 
         License::class.simpleName,
         MetaData::class.simpleName,
     )
-    val qualifiedFieldNames = mutableSetOf(
+    val excludedQualifiedFieldNames = mutableSetOf(
         "${Library::class.simpleName}.${Library::artifactId.name}",
         "${Library::class.simpleName}.${Library::groupId.name}",
         "${Library::class.simpleName}.${Library::artifactFolder.name}"
     )
-    val unqualifiedFieldNames = mutableSetOf<String>()
+    val excludedUnqualifiedFieldNames = mutableSetOf<String>()
     excludeFields.forEach { excludedField ->
         val segments = excludedField.split(".")
-        if (segments.size == 2 && allowedQualifiers.contains(segments.first())) {
-            qualifiedFieldNames.add(excludedField)
+        if (segments.size == 2 && allowedExclusionQualifiers.contains(segments.first())) {
+            excludedQualifiedFieldNames.add(excludedField)
         } else {
-            unqualifiedFieldNames.add(excludedField)
+            excludedUnqualifiedFieldNames.add(excludedField)
         }
     }
     val jsonGenerator = JsonGenerator.Options()
         .excludeNulls()
-        .excludeFieldsByName(unqualifiedFieldNames)
-        .addConverter(PartialObjectConverter(qualifiedFieldNames))
+        .excludeFieldsByName(excludedUnqualifiedFieldNames)
+        .addConverter(PartialObjectConverter(excludedQualifiedFieldNames))
         .build()
     PrintWriter(OutputStreamWriter(outputFile.outputStream(), StandardCharsets.UTF_8), true).use {
         it.write(jsonGenerator.toJson(this).let { json -> if (prettyPrint) JsonOutput.prettyPrint(json) else json })

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
@@ -7,7 +7,7 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods
 /**
  * A converter for [JsonGenerator], which allows properties to be excluded from the output.
  * The way it works is identical to the serialization of objects in [DefaultJsonGenerator].
- * @property excludedQualifiedPropertyNames The fully qualified name (package name + class name + property name)
+ * @property excludedQualifiedPropertyNames The qualified name (class name + property name)
  * of the properties that should be excluded from serialization.
  */
 class PartialObjectConverter(
@@ -21,12 +21,12 @@ class PartialObjectConverter(
     private val excludedPropertyNames = setOf("class", "declaringClass", "metaClass")
 
     override fun handles(type: Class<*>?): Boolean {
-        return type != null && targetClassNames.contains(type.name)
+        return type != null && targetClassNames.contains(type.simpleName)
     }
 
     override fun convert(value: Any, key: String?): Any {
         return DefaultGroovyMethods.getProperties(value).filterKeys { propertyName ->
-            propertyName !in excludedPropertyNames && "${value::class.qualifiedName}.$propertyName" !in excludedQualifiedPropertyNames
+            propertyName !in excludedPropertyNames && "${value::class.simpleName}.$propertyName" !in excludedQualifiedPropertyNames
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
@@ -5,27 +5,28 @@ import groovy.json.JsonGenerator
 import org.codehaus.groovy.runtime.DefaultGroovyMethods
 
 /**
- * A converter for [JsonGenerator], which allows properties of a certain type to be excluded from the output.
+ * A converter for [JsonGenerator], which allows properties to be excluded from the output.
  * The way it works is identical to the serialization of objects in [DefaultJsonGenerator].
- * @property targetClass The class that this converter should handle.
- * @param excludedFields The names of the object properties that should not be included in the output.
+ * @property excludedQualifiedPropertyNames The fully qualified name (package name + class name + property name)
+ * of the properties that should be excluded from serialization.
  */
 class PartialObjectConverter(
-    private val targetClass: Class<*>,
-    excludedFields: Iterable<String>
+    private val excludedQualifiedPropertyNames: Set<String>
 ) : JsonGenerator.Converter {
 
-    private val excludedPropertyNames: Set<String> = mutableSetOf("class", "declaringClass", "metaClass").apply {
-        addAll(excludedFields)
+    private val targetClassNames: Set<String> = excludedQualifiedPropertyNames.mapTo(mutableSetOf()) { field ->
+        field.substringBeforeLast('.')
     }
 
+    private val excludedPropertyNames = setOf("class", "declaringClass", "metaClass")
+
     override fun handles(type: Class<*>?): Boolean {
-        return targetClass == type
+        return type != null && targetClassNames.contains(type.name)
     }
 
     override fun convert(value: Any, key: String?): Any {
         return DefaultGroovyMethods.getProperties(value).filterKeys { propertyName ->
-            propertyName !in excludedPropertyNames
+            propertyName !in excludedPropertyNames && "${value::class.qualifiedName}.$propertyName" !in excludedQualifiedPropertyNames
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PartialObjectConverter.kt
@@ -1,0 +1,32 @@
+package com.mikepenz.aboutlibraries.plugin.util
+
+import groovy.json.DefaultJsonGenerator
+import groovy.json.JsonGenerator
+import org.codehaus.groovy.runtime.DefaultGroovyMethods
+
+/**
+ * A converter for [JsonGenerator], which allows properties of a certain type to be excluded from the output.
+ * The way it works is identical to the serialization of objects in [DefaultJsonGenerator].
+ * @property targetClass The class that this converter should handle.
+ * @param excludedFields The names of the object properties that should not be included in the output.
+ */
+class PartialObjectConverter(
+    private val targetClass: Class<*>,
+    excludedFields: Iterable<String>
+) : JsonGenerator.Converter {
+
+    private val excludedPropertyNames: Set<String> = mutableSetOf("class", "declaringClass", "metaClass").apply {
+        addAll(excludedFields)
+    }
+
+    override fun handles(type: Class<*>?): Boolean {
+        return targetClass == type
+    }
+
+    override fun convert(value: Any, key: String?): Any {
+        return DefaultGroovyMethods.getProperties(value).filterKeys { propertyName ->
+            propertyName !in excludedPropertyNames
+        }
+    }
+
+}


### PR DESCRIPTION
Resolves #1014 

Currently this solution removes the possibility to remove the metadata object from the output. It has never been documented that this works, but there may still be people who rely on it. If you think this is a problem, I have two ideas on how to solve it:

1) Apply `PartialObjectConverter` for `MetaData` as well
or
2) Add a new parameter in the configuration, e.g. `excludeMetaData`

What do you think?