### PR TITLE
Fix gradle deprecations

### DIFF
--- a/aboutlibraries-compose-m2/build.gradle.kts
+++ b/aboutlibraries-compose-m2/build.gradle.kts
@@ -21,7 +21,7 @@ android {
     }
 
     buildTypes {
-        getByName("release") {
+        named("release") {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
@@ -34,7 +34,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions {
             jvmTarget = "11"
 

--- a/aboutlibraries-compose-m3/build.gradle.kts
+++ b/aboutlibraries-compose-m3/build.gradle.kts
@@ -21,7 +21,7 @@ android {
     }
 
     buildTypes {
-        getByName("release") {
+        named("release") {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
@@ -34,7 +34,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions {
             jvmTarget = "11"
             if (project.findProperty("composeCompilerReports") == "true") {

--- a/aboutlibraries-core/build.gradle.kts
+++ b/aboutlibraries-core/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     }
 
     buildTypes {
-        getByName("release") {
+        named("release") {
             isMinifyEnabled = false
         }
     }
@@ -29,7 +29,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    tasks.withType<KotlinCompile> {
+    tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions {
             jvmTarget = "11"
             freeCompilerArgs += listOf(
@@ -52,7 +52,7 @@ kotlin {
     js(IR) {
         nodejs {}
         browser {}
-        compilations.all {
+        compilations.configureEach {
             kotlinOptions {
                 moduleKind = "umd"
                 sourceMap = true

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -29,12 +29,12 @@ dependencies {
     // implementation("org.apache.commons:commons-csv:1.9.0")
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = "11"
     targetCompatibility = "11"
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.jvmTarget = "11"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     stagingImplementation(libs.okhttp.core)
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.force(libs.fastAdapter.core)
     resolutionStrategy.force(libs.iconics.core)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,8 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 
 android.enableJetifier=false
 
-org.gradle.unsafe.configuration-cache=false
+org.gradle.caching=true
+org.gradle.configuration-cache=false
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/multiplatform-demo/build.gradle.kts
+++ b/multiplatform-demo/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 
 kotlin {
     jvm {
-        compilations.all {
+        compilations.configureEach {
             kotlinOptions.jvmTarget = "11"
         }
         withJava()
@@ -61,7 +61,7 @@ configure<AboutLibrariesExtension> {
     registerAndroidTasks = false
 }
 
-tasks.withType(KotlinCompile::class.java) {
+tasks.withType(KotlinCompile::class.java).configureEach {
     dependsOn("exportLibraryDefinitions")
 }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.util.GradleVersion
 import org.slf4j.LoggerFactory
+import java.io.File
 
 @Suppress("unused") // Public API for Gradle build scripts.
 class AboutLibrariesPlugin : Plugin<Project> {
@@ -53,14 +54,18 @@ class AboutLibrariesPlugin : Plugin<Project> {
                 it.description = "Writes the relevant meta data for the AboutLibraries plugin to display dependencies"
                 it.group = "Build"
                 it.variant = project.safeProp("aboutLibraries.exportVariant") ?: project.safeProp("exportVariant")
-                it.resultDirectory = project.file(
-                    project.safeProp("aboutLibraries.exportPath") ?: project.safeProp("exportPath")
-                    ?: "${project.buildDir}/generated/aboutLibraries/"
-                )
+
+                val exportPath = project.safeProp("aboutLibraries.exportPath") ?: project.safeProp("exportPath")
+                if (exportPath != null) {
+                    it.resultDirectory.set(File(exportPath))
+                } else {
+                    it.resultDirectory.set(project.layout.buildDirectory.dir("generated/aboutLibraries/"))
+                }
+
                 it.dependsOn(collectTask)
             }
 
-            val extension = project.extensions.getByName("aboutLibraries") as AboutLibrariesExtension
+            val extension = project.extensions.findByType(AboutLibrariesExtension::class.java)!!
             if (extension.registerAndroidTasks) {
                 AboutLibrariesPluginAndroidExtension.apply(project, collectTask)
             }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -15,12 +15,12 @@ object AboutLibrariesPluginAndroidExtension {
         try {
             val app = project.extensions.findByType(com.android.build.gradle.AppExtension::class.java)
             if (app != null) {
-                app.applicationVariants.all {
+                app.applicationVariants.configureEach {
                     createAboutLibrariesAndroidTasks(project, it, collectTask)
                 }
             } else {
                 val lib = project.extensions.findByType(com.android.build.gradle.LibraryExtension::class.java)
-                lib?.libraryVariants?.all {
+                lib?.libraryVariants?.configureEach {
                     createAboutLibrariesAndroidTasks(project, it, collectTask)
                 }
             }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -32,22 +32,25 @@ object AboutLibrariesPluginAndroidExtension {
     @Suppress("DEPRECATION")
     private fun createAboutLibrariesAndroidTasks(project: Project, v: Any, collectTask: TaskProvider<*>) {
         val variant = (v as? com.android.build.gradle.api.BaseVariant) ?: return
+
+        val resultsDirectory = project.layout.buildDirectory.dir("generated/aboutLibraries/${variant.name}/res/raw/")
+
         // task to write the general definitions information
-        val task = project.tasks.create(
+        val task = project.tasks.register(
             "prepareLibraryDefinitions${variant.name.capitalize(Locale.ENGLISH)}",
             AboutLibrariesTask::class.java
         ) {
             it.description = "Writes the relevant meta data for the AboutLibraries plugin to display dependencies"
             it.group = "Build"
             it.variant = variant.name
-            it.resultDirectory = project.file("${project.buildDir}/generated/aboutLibraries/${variant.name}/res/raw/")
+            it.resultDirectory.set(resultsDirectory)
             it.dependsOn(collectTask)
         }
 
         // This is necessary for backwards compatibility with versions of gradle that do not support
         // this new API.
         try {
-            variant.registerGeneratedResFolders(project.files(task.resultDirectory.parentFile).builtBy(task))
+            variant.registerGeneratedResFolders(project.files(resultsDirectory.get().asFile.parentFile).builtBy(task))
             try {
                 variant.mergeResourcesProvider.configure { it.dependsOn(task) }
             } catch (t: Throwable) {
@@ -56,7 +59,7 @@ object AboutLibrariesPluginAndroidExtension {
             }
         } catch (t: Throwable) {
             @Suppress("DEPRECATION")
-            variant.registerResGeneratingTask(task, task.resultDirectory.parentFile)
+            variant.registerResGeneratingTask(task.get(), resultsDirectory.get().asFile.parentFile)
         }
 
         // task to generate libraries, and their license into the build folder (not hooked to the build task)
@@ -67,7 +70,7 @@ object AboutLibrariesPluginAndroidExtension {
             it.description = "Manually write meta data for the AboutLibraries plugin"
             it.group = "Build"
             it.variant = variant.name
-            it.resultDirectory = project.file("${project.buildDir}/generated/aboutLibraries/${variant.name}/res/raw/")
+            it.resultDirectory.set(project.layout.buildDirectory.dir("generated/aboutLibraries/${variant.name}/res/raw/"))
             it.dependsOn(collectTask)
         }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -4,9 +4,15 @@ import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
 import com.mikepenz.aboutlibraries.plugin.model.writeToDisk
 import com.mikepenz.aboutlibraries.plugin.util.forLicense
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.LoggerFactory
@@ -21,20 +27,13 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
     @Input
     val outputFileName = extension.outputFileName
 
-    @Internal
-    var resultDirectory: File = project.file("${project.buildDir}/generated/aboutLibraries/res/")
-        set(value) {
-            field = value
-            combinedLibrariesOutputFile = File(resultDirectory, outputFileName)
-        }
-
-    @OutputFile
-    var combinedLibrariesOutputFile = File(resultDirectory, outputFileName)
+    @get:OutputDirectory
+    val resultDirectory: DirectoryProperty = project.objects.directoryProperty()
 
     @TaskAction
-    public fun action() {
-        if (!resultDirectory.exists()) {
-            resultDirectory.mkdirs() // verify output exists
+    fun action() {
+        if (!resultDirectory.get().asFile.exists()) {
+            resultDirectory.get().asFile.mkdirs() // verify output exists
         }
 
         val result = createLibraryProcessor().gatherDependencies()
@@ -104,6 +103,7 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
         }
 
         // write to disk
+        val combinedLibrariesOutputFile = resultDirectory.file(outputFileName).get().asFile
         result.writeToDisk(combinedLibrariesOutputFile, excludeFields, extension.prettyPrint)
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -5,10 +5,13 @@ import com.mikepenz.aboutlibraries.plugin.util.LibrariesProcessor
 import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.slf4j.LoggerFactory
@@ -21,7 +24,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     private val rootDir = project.rootDir
 
     @Internal
-    protected val extension = project.extensions.getByName("aboutLibraries") as AboutLibrariesExtension
+    protected val extension = project.extensions.findByType(AboutLibrariesExtension::class.java)!!
 
     @Internal
     open var variant: String? = null
@@ -31,7 +34,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
 
     @InputFile
     @PathSensitive(value = PathSensitivity.RELATIVE)
-    protected val dependencyCache = File(project.buildDir, "generated/aboutLibraries/dependency_cache.json")
+    val dependencyCache: Provider<RegularFile> = project.layout.buildDirectory.file("generated/aboutLibraries/dependency_cache.json")
 
     @org.gradle.api.tasks.Optional
     @PathSensitive(value = PathSensitivity.RELATIVE)
@@ -89,7 +92,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     @Suppress("UNCHECKED_CAST")
     protected fun readInCollectedDependencies(): CollectedContainer {
         try {
-            return CollectedContainer.from((JsonSlurper().parse(dependencyCache) as Map<String, *>)["dependencies"] as Map<String, Map<String, List<String>>>)
+            return CollectedContainer.from((JsonSlurper().parse(dependencyCache.get().asFile) as Map<String, *>)["dependencies"] as Map<String, Map<String, List<String>>>)
         } catch (t: Throwable) {
             throw IllegalStateException("Failed to parse the dependencyCache. Try to do a clean build", t)
         }


### PR DESCRIPTION
While debugging some issue (which later turned out to be https://github.com/mikepenz/AboutLibraries/issues/857) I made some changes along the way addressing some gradle deprecation warnings and use some lazy instead of eager APIs.

I does not amount to much, but thought it might be useful anyway to submit as a minor improvement. Feel free to close it though, especially since I did not do too much testing since I am not familiar with all use cases of the library. Tried my best though.

Main changes:
* Migrate from some eager gradle APIs to lazy equivalents (`all`, `withType` (without `configureEach`), `getByName`), see also https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#eager_apis_to_avoid
* Migrate away from `project.buildDir`
** This change avoids some minor IO during the configuration phase (creating the parent directory of the dependency cache file)