### PR TITLE
Fix dependency collection to match gradle task

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -126,7 +126,8 @@ class DependencyCollector(
 
                         else -> {
                             if (LOGGER.isDebugEnabled) LOGGER.debug("retrieve allModuleArtifacts from artifact")
-                            resolvedDependency.allModuleArtifacts
+                            resolvedDependency.allModuleArtifacts +
+                                    resolvedDependency.toResolvedBomArtifact()
                         }
                     }
                 } catch (e: Throwable) {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -126,8 +126,9 @@ class DependencyCollector(
 
                         else -> {
                             if (LOGGER.isDebugEnabled) LOGGER.debug("retrieve allModuleArtifacts from artifact")
-                            resolvedDependency.allModuleArtifacts +
-                                    resolvedDependency.toResolvedBomArtifact()
+                            val allArtifacts = resolvedDependency.allModuleArtifacts
+                            if (includePlatform) allArtifacts + resolvedDependency.toResolvedBomArtifact()
+                            allArtifacts
                         }
                     }
                 } catch (e: Throwable) {
@@ -135,6 +136,7 @@ class DependencyCollector(
                         LOGGER.isDebugEnabled -> {
                             LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency", e)
                         }
+
                         LOGGER.isInfoEnabled -> {
                             LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency")
                         }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
@@ -63,7 +63,7 @@ internal fun <T> chooseValue(uniqueId: String, key: String, value: Array<T>?, bl
 }
 
 /**
- * Convenient helper to wrap a [ResolvedDependency] into a []ResolvedArtifact]
+ * Convenient helper to wrap a [ResolvedDependency] into a [ResolvedArtifact]
  * Required to handle `platform` dependencies.
  */
 internal fun ResolvedDependency.toResolvedBomArtifact() = object : ResolvedArtifact {


### PR DESCRIPTION
Fix dependency collection to match closer the list of dependencies generated by `./gradlew dependencies`

Closes #1039 