### PR TITLE
Attempt to fix Kotlin 2.x incompatiblity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-conventionPlugin = "0.1.3"
+conventionPlugin = "0.1.4"
 # kotlin
 kotlinxSerialization = "1.7.3"
 kotlinxCollections = "0.3.8"

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -2,6 +2,7 @@ import java.io.FileInputStream
 import java.util.*
 
 plugins {
+    alias(baseLibs.plugins.kotlinJvm) apply false
     alias(libs.plugins.conventionPlugin)
     alias(baseLibs.plugins.dokka)
     alias(baseLibs.plugins.mavenPublish)

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             from(files("../gradle/libs.versions.toml"))
         }
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.0.4")
+            from("com.mikepenz:version-catalog:0.1.1")
         }
     }
 }


### PR DESCRIPTION
- apply the kotlin plugin to the plugin build (forcing Kotlin 2.x or newer)