### PR TITLE
Use `fromHtml` via `AnnotatedString` on Android

### DIFF
--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
@@ -1,28 +1,25 @@
 package com.mikepenz.aboutlibraries.ui.compose
 
 import android.content.Context
-import android.widget.TextView
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.text.HtmlCompat
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.data.fakeData
-import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -70,25 +67,12 @@ fun LibrariesContainer(
         header,
         onLibraryClick,
         licenseDialogBody = { library ->
-            HtmlText(
-                html = library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty(),
-                color = colors.contentColor,
+            Text(
+                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.licenseContent.orEmpty()),
+                color = colors.contentColor
             )
         }
     )
-}
-
-@Composable
-fun HtmlText(
-    html: String,
-    modifier: Modifier = Modifier,
-    color: Color = LibraryDefaults.libraryColors().contentColor,
-) {
-    AndroidView(modifier = modifier, factory = { context ->
-        TextView(context).apply {
-            setTextColor(color.toArgb())
-        }
-    }, update = { it.text = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT) })
 }
 
 @Preview("Library items (Default)")

--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.data.fakeData
+import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -68,7 +69,7 @@ fun LibrariesContainer(
         onLibraryClick,
         licenseDialogBody = { library ->
             Text(
-                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.licenseContent.orEmpty()),
+                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty()),
                 color = colors.contentColor
             )
         }

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.m3.data.fakeData
+import com.mikepenz.aboutlibraries.ui.compose.m3.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -68,7 +69,7 @@ fun LibrariesContainer(
         onLibraryClick,
         licenseDialogBody = { library ->
             Text(
-                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.licenseContent.orEmpty()),
+                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty()),
                 color = colors.contentColor
             )
         }

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
@@ -1,28 +1,25 @@
 package com.mikepenz.aboutlibraries.ui.compose.m3
 
 import android.content.Context
-import android.widget.TextView
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.text.HtmlCompat
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.m3.data.fakeData
-import com.mikepenz.aboutlibraries.ui.compose.m3.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -70,25 +67,12 @@ fun LibrariesContainer(
         header,
         onLibraryClick,
         licenseDialogBody = { library ->
-            HtmlText(
-                html = library.licenses.firstOrNull()?.htmlReadyLicenseContent.orEmpty(),
-                color = colors.contentColor,
+            Text(
+                text = AnnotatedString.fromHtml(library.licenses.firstOrNull()?.licenseContent.orEmpty()),
+                color = colors.contentColor
             )
         }
     )
-}
-
-@Composable
-fun HtmlText(
-    html: String,
-    modifier: Modifier = Modifier,
-    color: Color = LibraryDefaults.libraryColors().contentColor,
-) {
-    AndroidView(modifier = modifier, factory = { context ->
-        TextView(context).apply {
-            setTextColor(color.toArgb())
-        }
-    }, update = { it.text = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT) })
 }
 
 @Preview("Library items (Default)")

--- a/app-desktop/src/jvmMain/kotlin/m2/main.kt
+++ b/app-desktop/src/jvmMain/kotlin/m2/main.kt
@@ -1,5 +1,6 @@
 package m2
 
+import aboutlibraries.app_desktop.generated.resources.Res
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -10,7 +11,6 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
-import com.mikepenz.app_desktop.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 
 @OptIn(ExperimentalResourceApi::class)

--- a/app-desktop/src/jvmMain/kotlin/m3/main.kt
+++ b/app-desktop/src/jvmMain/kotlin/m3/main.kt
@@ -1,5 +1,6 @@
 package m3
 
+import aboutlibraries.app_desktop.generated.resources.Res
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -12,7 +13,6 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.m3.rememberLibraries
-import com.mikepenz.app_desktop.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalResourceApi::class)


### PR DESCRIPTION
- switch to AnnotatedString.fromHtml instead of depending on view based approach
- improve formatting