### PR TITLE
Add flag to skip spdx license name/url/content mapping

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -112,6 +112,18 @@ abstract class AboutLibrariesExtension {
     var strictMode = StrictMode.IGNORE
 
     /**
+     * Defines if licenses are mapped to SPDX identifiers.
+     * This lowers the meta data file size, however in case of modified license content, might loose the original license information - and instead use standard SPDX information, based on SPDX license id defined.
+     *
+     * ```
+     * aboutLibraries {
+     *   mapLicensesToSpdx = false
+     * }
+     * ```
+     */
+    var mapLicensesToSpdx: Boolean = true
+
+    /**
      * Defines the allowed licenses which will not result in warnings or failures depending on the [strictMode] configuration.
      *
      * ```

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -7,7 +7,13 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.slf4j.LoggerFactory
 import java.io.File
 import javax.inject.Inject
@@ -31,7 +37,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     @PathSensitive(value = PathSensitivity.RELATIVE)
     val dependencyCache: Provider<RegularFile> = project.layout.buildDirectory.file("generated/aboutLibraries/dependency_cache.json")
 
-    @org.gradle.api.tasks.Optional
+    @Optional
     @PathSensitive(value = PathSensitivity.RELATIVE)
     @InputDirectory
     fun getConfigPath(): File? {
@@ -63,6 +69,9 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val duplicationRule = extension.duplicationRule
 
     @Input
+    val mapLicensesToSpdx = extension.mapLicensesToSpdx
+
+    @Input
     val allowedLicenses = extension.allowedLicenses
 
     @Input
@@ -81,7 +90,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val additionalLicenses = extension.additionalLicenses.toHashSet()
 
     @Input
-    @org.gradle.api.tasks.Optional
+    @Optional
     val gitHubApiToken = extension.gitHubApiToken
 
     @Input
@@ -104,18 +113,19 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
 
     protected fun createLibraryProcessor(collectedContainer: CollectedContainer = readInCollectedDependencies()): LibrariesProcessor {
         return LibrariesProcessor(
-            getDependencyHandler(),
-            collectedContainer,
-            getConfigPath(),
-            exclusionPatterns,
-            offlineMode,
-            fetchRemoteLicense,
-            fetchRemoteFunding,
-            additionalLicenses,
-            duplicationMode,
-            duplicationRule,
-            variant.orNull,
-            gitHubApiToken
+            dependencyHandler = getDependencyHandler(),
+            collectedDependencies = collectedContainer,
+            configFolder = getConfigPath(),
+            exclusionPatterns = exclusionPatterns,
+            offlineMode = offlineMode,
+            fetchRemoteLicense = fetchRemoteLicense,
+            fetchRemoteFunding = fetchRemoteFunding,
+            additionalLicenses = additionalLicenses,
+            duplicationMode = duplicationMode,
+            duplicationRule = duplicationRule,
+            variant = variant.orNull,
+            mapLicensesToSpdx = mapLicensesToSpdx,
+            gitHubToken = gitHubApiToken
         )
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/Api.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/Api.kt
@@ -28,8 +28,8 @@ class Api private constructor(
     /**
      * Fetches the remote license for the given repository, and attaches them to the existing set.
      */
-    override fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>) {
-        resolveApi(repositoryLink?.url)?.fetchRemoteLicense(uniqueId, repositoryLink, licenses)
+    override fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>, mapLicensesToSpdx: Boolean) {
+        resolveApi(repositoryLink?.url)?.fetchRemoteLicense(uniqueId, repositoryLink, licenses, mapLicensesToSpdx)
     }
 
     /**
@@ -70,7 +70,7 @@ internal interface IApi {
     /**
      * Fetches the remote license as stored in the repository and updates the already covered licenses.
      */
-    fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>) {}
+    fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>, mapLicensesToSpdx: Boolean = true) {}
 
     /**
      * Fetches the funding for the given repository.

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/GitHubApi.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/api/GitHubApi.kt
@@ -45,7 +45,7 @@ internal class GitHubApi(
      * Fetch licenses from either the repository, or from spdx as txt format
      */
     @Suppress("UNCHECKED_CAST")
-    override fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>) {
+    override fun fetchRemoteLicense(uniqueId: String, repositoryLink: Scm?, licenses: HashSet<License>, mapLicensesToSpdx: Boolean) {
         val url = repositoryLink?.url
         if (rateLimit > 0 && url?.contains("github") == true) {
             LOGGER.debug("Remaining GitHub rate limit: $rateLimit")
@@ -54,7 +54,7 @@ internal class GitHubApi(
             if (licenses.isNotEmpty()) {
                 licenses.forEach {
                     if (it.spdxId != null && it.content == null) {
-                        it.loadSpdxLicense()
+                        it.loadSpdxLicense(mapLicensesToSpdx)
                     }
                 }
             } else {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
@@ -28,15 +28,19 @@ object LicenseUtil {
         }
     }
 
-    fun License.loadSpdxLicense() {
+    fun License.loadSpdxLicense(mapToSpdx: Boolean = true) {
         val spdxId = spdxId ?: return
         try {
             val enumLicense = SpdxLicense.find(spdxId)
             if (enumLicense != null) {
                 val singleLicense: String? = loadLicenseCached(enumLicense.getTxtUrl()) ?: loadLicenseCached(enumLicense.getFallbackTxtUrl())
                 if (singleLicense?.isNotBlank() == true) {
-                    name = enumLicense.fullName
-                    url = enumLicense.getUrl()
+                    if (mapToSpdx || name.isBlank()) {
+                        name = enumLicense.fullName
+                    }
+                    if (mapToSpdx || url.isNullOrBlank()) {
+                        url = enumLicense.getUrl()
+                    }
                     content = singleLicense
                 }
             } else {


### PR DESCRIPTION
- add flag to disable mapping to the spdx license
  - will keep original name or url as defined in pom.xml
