### PR TITLE
Fix license caching not properly checking fallback license url

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LicenseUtil.kt
@@ -14,7 +14,7 @@ object LicenseUtil {
     internal fun loadLicenseCached(url: String): String? {
         return try {
             if (remoteLicenseCache.containsKey(url)) {
-                remoteLicenseCache[url]
+                remoteLicenseCache[url]?.takeIf { it.isNotBlank() }
             } else {
                 remoteLicenseCache[url] = ""
                 URL(url).readText().let {


### PR DESCRIPTION
- Fix issue causing fallback licenses not being fetched if a prior run did store the non fallback as checked in the `remoteLicenseCache`
    - FIX https://github.com/mikepenz/AboutLibraries/issues/1085