### PR TITLE
Exclude kotlin-stdlib from plugin dependencies

### DIFF
--- a/plugin-build/plugin/gradle.properties
+++ b/plugin-build/plugin/gradle.properties
@@ -1,3 +1,7 @@
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false
+
 POM_NAME=AboutLibraries Library Gradle Plugin
 POM_DESCRIPTION=Resolve all dependencies used in a gradle module, with associated license and further information.
 POM_ARTIFACT_ID=aboutlibraries-plugin


### PR DESCRIPTION
https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library

```diff
diff --color=auto -r 12.0.0-b02-before/aboutlibraries-plugin-12.0.0-b02.module 12.0.0-b02-after/aboutlibraries-plugin-12.0.0-b02.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.20"
<           }
<         }
<       ],
66,72d56
<           }
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.20"
diff --color=auto -r 12.0.0-b02-before/aboutlibraries-plugin-12.0.0-b02.pom 12.0.0-b02-after/aboutlibraries-plugin-12.0.0-b02.pom
16,21d15
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.1.20</version>
<       <scope>compile</scope>
<     </dependency>
<     <dependency>
```