### PR TITLE
[A] Filter out project modules

### DIFF
--- a/plugin-build/plugin/gradle.properties
+++ b/plugin-build/plugin/gradle.properties
@@ -1,8 +1,9 @@
-# Omit automatic compile dependency on kotlin-stdlib.
-# https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
-kotlin.stdlib.default.dependency=false
-
 POM_NAME=AboutLibraries Library Gradle Plugin
 POM_DESCRIPTION=Resolve all dependencies used in a gradle module, with associated license and further information.
 POM_ARTIFACT_ID=aboutlibraries-plugin
 GROUP=com.mikepenz.aboutlibraries.plugin
+
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false
+

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -108,8 +108,6 @@ class DependencyCollector(
             if (name !in visitedDependencyNames) {
                 visitedDependencyNames += name
 
-                if (LOGGER.isDebugEnabled) LOGGER.debug("handling resolved artifact :: $name")
-
                 try {
                     resolvedArtifacts += when {
                         resolvedDependency.moduleVersion == "unspecified" -> {
@@ -130,16 +128,13 @@ class DependencyCollector(
                             if (includePlatform) allArtifacts + resolvedDependency.toResolvedBomArtifact()
                             allArtifacts
                         }
+                    }.filter {
+                        it.file.isFile // filter out artifacts that are folders (these are modules within the project)
                     }
                 } catch (e: Throwable) {
                     when {
-                        LOGGER.isDebugEnabled -> {
-                            LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency", e)
-                        }
-
-                        LOGGER.isInfoEnabled -> {
-                            LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency")
-                        }
+                        LOGGER.isDebugEnabled -> LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency", e)
+                        LOGGER.isInfoEnabled -> LOGGER.warn("Found possibly ambiguous variant - $resolvedDependency")
                     }
                 }
             }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PomLoader.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/PomLoader.kt
@@ -31,8 +31,8 @@ object PomLoader {
                 .withArtifacts(MavenModule::class.java, MavenPomArtifact::class.java)
                 .execute()
 
-            if (resolutionResult.resolvedComponents.size == 0) {
-                LibrariesProcessor.LOGGER.error("${prefix}--> Retrieved no components for: $id")
+            if (resolutionResult.resolvedComponents.isEmpty()) {
+                LOGGER.info("{}--> Retrieved no components for: {}", prefix, id)
             }
 
             // size is 0 for gradle plugins, 1 for normal dependencies


### PR DESCRIPTION
Fixes: https://github.com/mikepenz/AboutLibraries/issues/1115

Filter out modules that are pure folders. 
Adjust log level to info to reduce noise for other modules that might not have a `*.pom`