### PR TITLE
Improve log in case of wrong `exportVariant` being used

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -56,6 +56,7 @@ class DependencyCollector(
                         return@mapNotNull variant to it
                     } else {
                         LOGGER.info("Skipping compile time variant $variant from config: ${it.name}")
+                        mutableCollectContainer.getOrPut(variant) { mutableMapOf() }
                     }
                 } else if (cn.endsWith("RuntimeClasspath", true)) {
                     val variant = cn.removeSuffix("RuntimeClasspath")
@@ -64,6 +65,7 @@ class DependencyCollector(
                         return@mapNotNull variant to it
                     } else {
                         LOGGER.info("Skipping compile time variant $variant from config: ${it.name}")
+                        mutableCollectContainer.getOrPut(variant) { mutableMapOf() }
                     }
                 }
 


### PR DESCRIPTION
- keep all variants in the collected container to provide additional context in case of unavailable export variant being provided