### PR TITLE
Add `afterEvaluate` for Android task

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -40,7 +40,10 @@ class AboutLibrariesPlugin : Plugin<Project> {
         }
 
         if (extension.android.registerAndroidTasks.getOrElse(true)) {
-            AboutLibrariesPluginAndroidExtension.apply(project, extension)
+            LOGGER.info("Registering Android tasks")
+            project.afterEvaluate {
+                AboutLibrariesPluginAndroidExtension.apply(it, extension)
+            }
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -40,6 +40,7 @@ class AboutLibrariesPlugin : Plugin<Project> {
         }
 
         if (extension.android.registerAndroidTasks.getOrElse(true)) {
+            LOGGER.debug("Registering Android tasks")
             AboutLibrariesPluginAndroidExtension.apply(project, extension)
         }
     }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPlugin.kt
@@ -40,10 +40,7 @@ class AboutLibrariesPlugin : Plugin<Project> {
         }
 
         if (extension.android.registerAndroidTasks.getOrElse(true)) {
-            LOGGER.info("Registering Android tasks")
-            project.afterEvaluate {
-                AboutLibrariesPluginAndroidExtension.apply(it, extension)
-            }
+            AboutLibrariesPluginAndroidExtension.apply(project, extension)
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -11,24 +11,28 @@ object AboutLibrariesPluginAndroidExtension {
     private val LOGGER = LoggerFactory.getLogger(AboutLibrariesPluginAndroidExtension::class.java)
 
     fun apply(project: Project, extension: AboutLibrariesExtension) {
-        try {
+        project.pluginManager.withPlugin("com.android.application") {
+            LOGGER.debug("Registering Android task for Application")
+
             val app = project.extensions.findByType(com.android.build.gradle.AppExtension::class.java)
             if (app != null) {
                 app.applicationVariants.configureEach {
                     createAboutLibrariesAndroidTasks(project, extension, it)
                 }
             } else {
-                val lib = project.extensions.findByType(com.android.build.gradle.LibraryExtension::class.java)
-                if (lib != null) {
-                    lib.libraryVariants.configureEach {
-                        createAboutLibrariesAndroidTasks(project, extension, it)
-                    }
-                } else {
-                    LOGGER.info("No Android extension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
-                }
+                LOGGER.warn("No Android AppExtension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
             }
-        } catch (t: Throwable) {
-            LOGGER.warn("Couldn't register Android related plugin tasks")
+        }
+        project.pluginManager.withPlugin("com.android.library") {
+            LOGGER.debug("Registering Android task for Library")
+            val lib = project.extensions.findByType(com.android.build.gradle.LibraryExtension::class.java)
+            if (lib != null) {
+                lib.libraryVariants.configureEach {
+                    createAboutLibrariesAndroidTasks(project, extension, it)
+                }
+            } else {
+                LOGGER.warn("No Android LibraryExtension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
+            }
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -19,8 +19,12 @@ object AboutLibrariesPluginAndroidExtension {
                 }
             } else {
                 val lib = project.extensions.findByType(com.android.build.gradle.LibraryExtension::class.java)
-                lib?.libraryVariants?.configureEach {
-                    createAboutLibrariesAndroidTasks(project, extension, it)
+                if (lib != null) {
+                    lib.libraryVariants.configureEach {
+                        createAboutLibrariesAndroidTasks(project, extension, it)
+                    }
+                } else {
+                    LOGGER.info("No Android extension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
                 }
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
- attempt to fix https://github.com/mikepenz/AboutLibraries/issues/1130

This will make sure the AboutLibraries plugin can be applied before the Android plugin