### PR TITLE
Introduce Gradle Property to pass `outputPath` via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ aboutLibraries {
 
     android {
         // - If the automatic registered android tasks are disabled, a similar thing can be achieved manually
-        // - `./gradlew app:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/res/raw`
+        // - `./gradlew app:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/res/raw/aboutlibraries.json`
         // - the resulting file can for example be added as part of the SCM
-        // - the `exportPath` can also be changed by setting `outputPath` via the DSL.
+        // - the `outputPath` can also be changed by setting `outputPath` via the DSL.
         registerAndroidTasks = false
     }
 
@@ -343,11 +343,11 @@ the dependency meta information and include as part of the SCM.
 ### Generate Dependency Information
 
 ```bash
-./gradlew :app-desktop:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/resources/
+./gradlew :app-desktop:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/resources/libraries.json
 
 # Filter exported definition by variant by passing `-PaboutLibraries.exportVariant==<VARIANT>`
-./gradlew :app-wasm:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/resources/ -PaboutLibraries.exportVariant=wasmJs
-./gradlew :app-wasm:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/resources/ -PaboutLibraries.exportVariant=jvm
+./gradlew :app-wasm:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/resources/libraries.json -PaboutLibraries.exportVariant=wasmJs
+./gradlew :app-wasm:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/resources/libraries.json -PaboutLibraries.exportVariant=jvm
 ```
 
 ### Run Demo app(s)
@@ -484,7 +484,7 @@ After disabling the integration it is possible to manually update the definition
 # Generate using the configured location
 ./gradlew app:exportLibraryDefinitions
 # Generate providing a custom path and variant
-./gradlew app:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/res/raw/ -PaboutLibraries.exportVariant=release
+./gradlew app:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/res/raw/libraries.json -PaboutLibraries.exportVariant=release
 ```
 
 This generated file can be either included in your SCM, and every build will use this exact verified and approved state.
@@ -510,9 +510,9 @@ For other environments or for more advanced usages the plugin offers additional 
 ```bash
 # Manually generate the dependency metaData in the provided location. Allows to commit it in SCM
 # Exports the metaData in `src/main/resources/` relative to the module root
-./gradlew app-desktop:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/resources/
+./gradlew app-desktop:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/resources/libraries.json
 # Export only for a specific variant: `release`
-./gradlew app-desktop:exportLibraryDefinitions -PaboutLibraries.exportPath=src/main/resources/ -PaboutLibraries.exportVariant=release
+./gradlew app-desktop:exportLibraryDefinitions -PaboutLibraries.outputPath=src/main/resources/libraries.json -PaboutLibraries.exportVariant=release
 
 # Export dependencies to CLI in CSV format
 ./gradlew app:exportLibraries
@@ -523,7 +523,7 @@ For other environments or for more advanced usages the plugin offers additional 
 
 # Exports all dependencies in a format helpful for compliance reports.
 # By default writes `export.csv` and `export.txt` and `dependencies` folder in the root of the project.
-./gradlew app:exportComplianceLibraries${Variant}
+./gradlew app:exportComplianceLibraries${Variant} -PaboutLibraries.exportPath=complianceReport/
 
 # List all funding options for included projects (as identified via the e.g.: GitHub API)
 ./gradlew app:fundLibraries

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
@@ -1,5 +1,8 @@
 package com.mikepenz.aboutlibraries.plugin
 
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_ARTIFACT_GROUPS
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_PATH
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_PREFIX
 import com.mikepenz.aboutlibraries.plugin.mapping.SpdxLicense
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -25,9 +28,9 @@ abstract class AboutLibrariesExportComplianceTask : BaseAboutLibrariesTask() {
 
     @Input
     @Optional
-    val exportPath: Provider<Directory> = project.providers.gradleProperty("aboutLibraries.exportPath")
+    val exportPath: Provider<Directory> = project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}")
         .map { path -> projectDirectory.get().dir(path) }
-        .orElse(project.providers.gradleProperty("exportPath").map { path ->
+        .orElse(project.providers.gradleProperty(PROP_EXPORT_PATH).map { path ->
             projectDirectory.get().dir(path)
         })
         .orElse(
@@ -42,8 +45,8 @@ abstract class AboutLibrariesExportComplianceTask : BaseAboutLibrariesTask() {
         )
 
     @Input
-    val artifactGroups: Provider<String> = project.providers.gradleProperty("aboutLibraries.artifactGroups").orElse(
-        project.providers.gradleProperty("artifactGroups")
+    val artifactGroups: Provider<String> = project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_ARTIFACT_GROUPS}").orElse(
+        project.providers.gradleProperty(PROP_EXPORT_ARTIFACT_GROUPS)
     ).orElse("")
 
     @Internal

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -264,6 +264,7 @@ abstract class AboutLibrariesExtension {
         internal const val PROP_EXPORT_VARIANT = "exportVariant"
         internal const val PROP_EXPORT_PATH = "exportPath"
         internal const val PROP_EXPORT_ARTIFACT_GROUPS = "artifactGroups"
+        internal const val PROP_EXPORT_OUTPUT_PATH = "outputPath"
     }
 }
 
@@ -399,7 +400,7 @@ abstract class ExportConfig @Inject constructor() {
      * Adjusting the file name will break the automatic discovery for supported platforms.
      * Ensure to use the respective APIs of the core module.
      *
-     * This can be overwritten with the `-PaboutLibraries.exportPath` command line argument.
+     * This can also be overwritten with the `-PaboutLibraries.outputPath` command line argument.
      *
      * ```
      * aboutLibraries {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -260,6 +260,10 @@ abstract class AboutLibrariesExtension {
 
     companion object {
         private const val DEFAULT_OUTPUT_NAME = "aboutlibraries.json"
+        internal const val PROP_PREFIX = "aboutLibraries."
+        internal const val PROP_EXPORT_VARIANT = "exportVariant"
+        internal const val PROP_EXPORT_PATH = "exportPath"
+        internal const val PROP_EXPORT_ARTIFACT_GROUPS = "artifactGroups"
     }
 }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -1,5 +1,6 @@
 package com.mikepenz.aboutlibraries.plugin
 
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_OUTPUT_PATH
 import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_PATH
 import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_PREFIX
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
@@ -37,11 +38,14 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
 
             @Suppress("DEPRECATION")
             val outputFileName = extension.export.outputFileName.get()
+            val providers = project.providers
             this.outputFile.set(
-                project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
-                    project.providers.gradleProperty(PROP_EXPORT_PATH).map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
-                    extension.export.outputPath.orElse(
-                        buildDirectory.dir("generated/aboutLibraries/").map { it.file(outputFileName) }
+                providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
+                    providers.gradleProperty(PROP_EXPORT_PATH).map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
+                    providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_OUTPUT_PATH}").map { path -> projectDirectory.file(path) }.orElse(
+                        extension.export.outputPath.orElse(
+                            buildDirectory.dir("generated/aboutLibraries/").map { it.file(outputFileName) }
+                        )
                     )
                 )
             )

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -1,5 +1,7 @@
 package com.mikepenz.aboutlibraries.plugin
 
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_PATH
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_PREFIX
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
 import com.mikepenz.aboutlibraries.plugin.model.ResultContainer
@@ -36,8 +38,8 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
             @Suppress("DEPRECATION")
             val outputFileName = extension.export.outputFileName.get()
             this.outputFile.set(
-                project.providers.gradleProperty("aboutLibraries.exportPath").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
-                    project.providers.gradleProperty("exportPath").map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
+                project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
+                    project.providers.gradleProperty(PROP_EXPORT_PATH).map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
                     extension.export.outputPath.orElse(
                         buildDirectory.dir("generated/aboutLibraries/").map { it.file(outputFileName) }
                     )

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -40,9 +40,9 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
             val outputFileName = extension.export.outputFileName.get()
             val providers = project.providers
             this.outputFile.set(
-                providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
-                    providers.gradleProperty(PROP_EXPORT_PATH).map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
-                    providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_OUTPUT_PATH}").map { path -> projectDirectory.file(path) }.orElse(
+                providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_OUTPUT_PATH}").map { path -> projectDirectory.file(path) }.orElse(
+                    providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}").map { path -> projectDirectory.dir(path).file(outputFileName) }.orElse(
+                        providers.gradleProperty(PROP_EXPORT_PATH).map { path -> projectDirectory.dir(path).file(outputFileName) }).orElse(
                         extension.export.outputPath.orElse(
                             buildDirectory.dir("generated/aboutLibraries/").map { it.file(outputFileName) }
                         )

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -1,5 +1,7 @@
 package com.mikepenz.aboutlibraries.plugin
 
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_VARIANT
+import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_PREFIX
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
 import com.mikepenz.aboutlibraries.plugin.model.CollectedContainer
@@ -101,8 +103,8 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     open fun configure() {
         if (!variant.isPresent) {
             variant.set(
-                project.providers.gradleProperty("aboutLibraries.exportVariant").orElse(
-                    project.providers.gradleProperty("exportVariant").orElse(
+                project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_VARIANT}").orElse(
+                    project.providers.gradleProperty(PROP_EXPORT_VARIANT).orElse(
                         extension.export.exportVariant
                     )
                 )

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -67,6 +67,8 @@ class DependencyCollector(
                         LOGGER.info("Skipping compile time variant $variant from config: ${it.name}")
                         mutableCollectContainer.getOrPut(variant) { mutableMapOf() }
                     }
+                } else {
+                    LOGGER.debug("Skipping configuration $cn")
                 }
 
                 null

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/Extensions.kt
@@ -3,20 +3,14 @@ package com.mikepenz.aboutlibraries.plugin.util
 import com.mikepenz.aboutlibraries.plugin.mapping.Library
 import com.mikepenz.aboutlibraries.plugin.mapping.License
 import com.mikepenz.aboutlibraries.plugin.util.parser.PomReader
-import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.ResolvedModuleVersion
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.provider.Provider
 import java.io.File
 import java.security.MessageDigest
-
-internal val Project.experimentalCache: Provider<Boolean>
-    get() = providers.gradleProperty("org.gradle.unsafe.configuration-cache").map { it == "true" }.orElse(
-        providers.gradleProperty("org.gradle.configuration-cache").map { it == "true" })
 
 internal infix fun <T> List<PomReader>?.first(read: PomReader.() -> T?): T? {
     this ?: return null


### PR DESCRIPTION
- move property keys to Extension 
- small cleanup
- update README 
- introduce new `PaboutLibraries.outputPath=` CLI argument to configure output path (equal to DSL)
    - FIX #1134
- new outputPath prop takes priority over exportPath and over DSL config