### PR TITLE
Improves license name matching.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,10 @@ dependencies {
 
     // used only tho showcase multi flavor support
     "stagingImplementation"(libs.okhttp.core)
+
+    // used to test matching of license names
+    implementation("com.github.librepdf:openpdf:1.3.43")
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
 }
 
 configurations.configureEach {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,12 +125,12 @@ dependencies {
     implementation(compose.components.resources)
     implementation(compose.materialIconsExtended)
 
-    //used to generate the drawer on the left
-    //https://github.com/mikepenz/MaterialDrawer
+    // used to generate the drawer on the left
+    // https://github.com/mikepenz/MaterialDrawer
     implementation(libs.materialDrawer.core)
 
-    //used to provide different itemAnimators for the RecyclerView
-    //https://github.com/mikepenz/ItemAnimators
+    // used to provide different itemAnimators for the RecyclerView
+    // https://github.com/mikepenz/ItemAnimators
     implementation(libs.itemAnimators.core)
 
     // used to provide out of the box icon font support. simplifies development,
@@ -138,16 +138,16 @@ dependencies {
     // https://github.com/mikepenz/Android-Iconics
     implementation(libs.iconics.core)
 
-    //used to display the icons in the drawer
-    //https://github.com/mikepenz/Android-Iconicsx`
+    // used to display the icons in the drawer
+    // https://github.com/mikepenz/Android-Iconicsx`
     implementation("com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar")
 
     // used only tho showcase multi flavor support
     "stagingImplementation"(libs.okhttp.core)
 
     // used to test matching of license names
-    implementation("com.github.librepdf:openpdf:1.3.43")
-    implementation("com.google.android.play:app-update-ktx:2.1.0")
+//    implementation("com.github.librepdf:openpdf:1.3.43")
+//    implementation("com.google.android.play:app-update-ktx:2.1.0")
 }
 
 configurations.configureEach {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -210,14 +210,17 @@ enum class SpdxLicense(
     LGPL_2_0_or_later("GNU Library General Public License v2 or later", "LGPL-2.0-or-later"),
     LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only",
         customMatcher = { name, _ ->
-            Regex(
-                "GNU Lesser General Public License( \\(LGPL\\))?,? (v|Version) ?2\\.1( only)?",
-                RegexOption.IGNORE_CASE
-            ).containsMatchIn(name)
+            name.equals("GNU Lesser General Public License v2.1 only", true)
+                    || name.equals("GNU Lesser General Public License (LGPL), Version 2.1", true)
         }
     ),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
-    LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only"),
+    LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only",
+        customMatcher = { name, _ ->
+            name.equals("GNU Lesser General Public License v3.0 only", true)
+                    || name.equals("GNU General Lesser Public License (LGPL) version 3.0", true)
+        }
+    ),
     LGPL_3_0_or_later("GNU Lesser General Public License v3.0 or later", "LGPL-3.0-or-later"),
     LGPLLR("Lesser General Public License For Linguistic Resources", "LGPLLR"),
     Libpng("libpng License", "Libpng"),
@@ -247,11 +250,10 @@ enum class SpdxLicense(
     MPL_1_0("Mozilla Public License 1.0", "MPL-1.0"),
     MPL_1_1("Mozilla Public License 1.1", "MPL-1.1"),
     MPL_2_0("Mozilla Public License 2.0", "MPL-2.0",
-        customMatcher = { name, _ ->
-            Regex(
-                "Mozilla Public License( Version)? 2\\.0",
-                RegexOption.IGNORE_CASE
-            ).containsMatchIn(name)
+        customMatcher = { name, url ->
+            name.contains("Mozilla Public License", true)
+                    && url?.contains("mozilla.org", true) == true
+                    && url.contains("MPL/2.0", true)
         }
     ),
     MPL_2_0_no_copyleft_exception(

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -208,6 +208,10 @@ enum class SpdxLicense(
     Leptonica("Leptonica License", "Leptonica"),
     LGPL_2_0_only("GNU Library General Public License v2 only", "LGPL-2.0-only"),
     LGPL_2_0_or_later("GNU Library General Public License v2 or later", "LGPL-2.0-or-later"),
+    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only", customMatcher = { name, _ ->
+        name.contains("GNU Lesser General Public License", true)
+                && name.contains("2.1", true)
+    }),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
     LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only"),
     LGPL_3_0_or_later("GNU Lesser General Public License v3.0 or later", "LGPL-3.0-or-later"),
@@ -238,6 +242,10 @@ enum class SpdxLicense(
     mpich2("mpich2 License", "mpich2"),
     MPL_1_0("Mozilla Public License 1.0", "MPL-1.0"),
     MPL_1_1("Mozilla Public License 1.1", "MPL-1.1"),
+    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0", customMatcher = { name, _ ->
+        name.contains("Mozilla Public License", true)
+                && name.contains("2.0", true)
+    }),
     MPL_2_0_no_copyleft_exception(
         "Mozilla Public License 2.0 (no copyleft exception)",
         "MPL-2.0-no-copyleft-exception"
@@ -405,16 +413,8 @@ enum class SpdxLicense(
             || name.equals("BSD 3-clause", true)
             || url?.endsWith("opensource.org/licenses/BSD-3-Clause", true) == true
     }),
-    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only", customMatcher = { name, _ ->
-        name.contains("GNU Lesser General Public License", true)
-                && name.contains("2.1", true)
-    }),
     MIT("MIT License", "MIT", customMatcher = { name, _ ->
         name.contains("MIT", true)
-    }),
-    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0", customMatcher = { name, _ ->
-        name.contains("Mozilla Public License", true)
-                && name.contains("2.0", true)
     }),
     CC0_1_0("Creative Commons Zero v1.0 Universal", "CC0-1.0", customMatcher = { name, _ ->
         name.equals("CC0", true)

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -208,7 +208,6 @@ enum class SpdxLicense(
     Leptonica("Leptonica License", "Leptonica"),
     LGPL_2_0_only("GNU Library General Public License v2 only", "LGPL-2.0-only"),
     LGPL_2_0_or_later("GNU Library General Public License v2 or later", "LGPL-2.0-or-later"),
-    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only"),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
     LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only"),
     LGPL_3_0_or_later("GNU Lesser General Public License v3.0 or later", "LGPL-3.0-or-later"),
@@ -239,7 +238,6 @@ enum class SpdxLicense(
     mpich2("mpich2 License", "mpich2"),
     MPL_1_0("Mozilla Public License 1.0", "MPL-1.0"),
     MPL_1_1("Mozilla Public License 1.1", "MPL-1.1"),
-    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0"),
     MPL_2_0_no_copyleft_exception(
         "Mozilla Public License 2.0 (no copyleft exception)",
         "MPL-2.0-no-copyleft-exception"
@@ -407,8 +405,16 @@ enum class SpdxLicense(
             || name.equals("BSD 3-clause", true)
             || url?.endsWith("opensource.org/licenses/BSD-3-Clause", true) == true
     }),
+    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only", customMatcher = { name, _ ->
+        name.contains("GNU Lesser General Public License", true)
+                && name.contains("2.1", true)
+    }),
     MIT("MIT License", "MIT", customMatcher = { name, _ ->
         name.contains("MIT", true)
+    }),
+    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0", customMatcher = { name, _ ->
+        name.contains("Mozilla Public License", true)
+                && name.contains("2.0", true)
     }),
     CC0_1_0("Creative Commons Zero v1.0 Universal", "CC0-1.0", customMatcher = { name, _ ->
         name.equals("CC0", true)
@@ -421,8 +427,19 @@ enum class SpdxLicense(
     }),
 
     // Special proprietary libraries section
-    ASDKL("Android Software Development Kit License", "ASDKL"),
-    CTS("Crashlytics Terms of Service", "CTS"),
+    ASDKL(
+        "Android Software Development Kit License",
+        "ASDKL",
+        customUrl = "https://developer.android.com/studio/terms.html",
+        customMatcher = { name, _ ->
+            name.contains("Android Software Development Kit License", false)
+        }
+    ),
+    CTS(
+        "Crashlytics Terms of Service",
+        "CTS",
+        customUrl = "https://firebase.google.com/terms/crashlytics.html",
+    ),
     FSSA("Fabric Software and Services Agreement", "FSSA"),
     GPL_2_0_CPE(
         "GNU General Public License, version 2, with the Classpath Exception",
@@ -430,6 +447,14 @@ enum class SpdxLicense(
         customUrl = "https://openjdk.org/legal/gplv2+ce.html",
         customMatcher = { name, url ->
             url?.equals("https://www.gnu.org/software/classpath/license.html") == true
+        }
+    ),
+    PCSDKToS(
+        "Play Core Software Development Kit Terms of Service",
+        "PCSDKToS",
+        customUrl = "https://developer.android.com/guide/playcore.html#license",
+        customMatcher = { name, _ ->
+            name.contains("Play Core Software Development Kit", true)
         }
     );
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -211,6 +211,7 @@ enum class SpdxLicense(
     LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only", customMatcher = { name, _ ->
         name.contains("GNU Lesser General Public License", true)
                 && name.contains("2.1", true)
+                && !name.contains("later")
     }),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
     LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only"),

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -208,11 +208,14 @@ enum class SpdxLicense(
     Leptonica("Leptonica License", "Leptonica"),
     LGPL_2_0_only("GNU Library General Public License v2 only", "LGPL-2.0-only"),
     LGPL_2_0_or_later("GNU Library General Public License v2 or later", "LGPL-2.0-or-later"),
-    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only", customMatcher = { name, _ ->
-        name.contains("GNU Lesser General Public License", true)
-                && name.contains("2.1", true)
-                && !name.contains("later")
-    }),
+    LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only",
+        customMatcher = { name, _ ->
+            Regex(
+                "GNU Lesser General Public License( \\(LGPL\\))?,? (v|Version) ?2\\.1( only)?",
+                RegexOption.IGNORE_CASE
+            ).containsMatchIn(name)
+        }
+    ),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
     LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only"),
     LGPL_3_0_or_later("GNU Lesser General Public License v3.0 or later", "LGPL-3.0-or-later"),
@@ -243,10 +246,14 @@ enum class SpdxLicense(
     mpich2("mpich2 License", "mpich2"),
     MPL_1_0("Mozilla Public License 1.0", "MPL-1.0"),
     MPL_1_1("Mozilla Public License 1.1", "MPL-1.1"),
-    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0", customMatcher = { name, _ ->
-        name.contains("Mozilla Public License", true)
-                && name.contains("2.0", true)
-    }),
+    MPL_2_0("Mozilla Public License 2.0", "MPL-2.0",
+        customMatcher = { name, _ ->
+            Regex(
+                "Mozilla Public License( Version)? 2\\.0",
+                RegexOption.IGNORE_CASE
+            ).containsMatchIn(name)
+        }
+    ),
     MPL_2_0_no_copyleft_exception(
         "Mozilla Public License 2.0 (no copyleft exception)",
         "MPL-2.0-no-copyleft-exception"

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/mapping/SpdxLicense.kt
@@ -210,15 +210,13 @@ enum class SpdxLicense(
     LGPL_2_0_or_later("GNU Library General Public License v2 or later", "LGPL-2.0-or-later"),
     LGPL_2_1_only("GNU Lesser General Public License v2.1 only", "LGPL-2.1-only",
         customMatcher = { name, _ ->
-            name.equals("GNU Lesser General Public License v2.1 only", true)
-                    || name.equals("GNU Lesser General Public License (LGPL), Version 2.1", true)
+            name.equals("GNU Lesser General Public License (LGPL), Version 2.1", true)
         }
     ),
     LGPL_2_1_or_later("GNU Lesser General Public License v2.1 or later", "LGPL-2.1-or-later"),
     LGPL_3_0_only("GNU Lesser General Public License v3.0 only", "LGPL-3.0-only",
         customMatcher = { name, _ ->
-            name.equals("GNU Lesser General Public License v3.0 only", true)
-                    || name.equals("GNU General Lesser Public License (LGPL) version 3.0", true)
+            name.equals("GNU General Lesser Public License (LGPL) version 3.0", true)
         }
     ),
     LGPL_3_0_or_later("GNU Lesser General Public License v3.0 or later", "LGPL-3.0-or-later"),


### PR DESCRIPTION
- Adds dependencies to sample project to test license name parsing
- Improves name matching for:
   - GNU Lesser General Public License (LGPL), Version 2.1
   - Mozilla Public License Version 2.0
- Adds some meta information for:
   - ASDKL
   - CTS
- Adds license name info for: 
   -  Play Core Software Development Kit Terms of Service