### PR TITLE
[WIP] Make compose ui modules more flexible | Refine visualization

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 #### v12.2.0
 
 - **Breaking Change**: Renamed `nameTextStyles` in `libraryTextStyles`/`LibraryTextStyles` to `nameTextStyle` (to align with other styles).
+- **Breaking Change**: Introduced new `libraryPadding()` default function to replace the existing one. This moves to use a new class to hold chip paddings.
 - 
 #### v12.0.0
 

--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
@@ -28,6 +29,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibrariesContainer(
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     librariesBlock: (Context) -> Libs = { context ->
         Libs.Builder().withContext(context).build()
     },
@@ -37,6 +39,7 @@ fun LibrariesContainer(
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -45,6 +48,7 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -56,12 +60,14 @@ fun LibrariesContainer(
     LibrariesContainer(
         libraries = libraries.value,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -70,6 +76,7 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
         licenseDialogBody = { library ->
             val license = remember(library) {
                 library.htmlReadyLicenseContent.takeIf { it.isNotEmpty() }?.let { AnnotatedString.fromHtml(it) }

--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -52,13 +53,13 @@ fun LibrariesContainer(
 ) {
     val context = LocalContext.current
 
-    val libraries = produceState<Libs?>(null) {
+    val libraries by produceState<Libs?>(null) {
         value = withContext(Dispatchers.IO) {
             librariesBlock(context)
         }
     }
     LibrariesContainer(
-        libraries = libraries.value,
+        libraries = libraries,
         modifier = modifier,
         libraryModifier = libraryModifier,
         lazyListState = lazyListState,

--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/AndroidLibraries.kt
@@ -6,20 +6,15 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
-import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -27,6 +22,7 @@ import kotlinx.coroutines.withContext
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     modifier: Modifier = Modifier,
@@ -78,16 +74,8 @@ fun LibrariesContainer(
         footer = footer,
         onLibraryClick = onLibraryClick,
         onFundingClick = onFundingClick,
-        licenseDialogBody = { library ->
-            val license = remember(library) {
-                library.htmlReadyLicenseContent.takeIf { it.isNotEmpty() }?.let { AnnotatedString.fromHtml(it) }
-            }
-            if (license != null) {
-                Text(
-                    text = license,
-                    color = colors.contentColor
-                )
-            }
+        licenseDialogBody = { library, modifier ->
+            LicenseDialogBody(library, colors, modifier)
         }
     )
 }

--- a/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.android.kt
+++ b/aboutlibraries-compose-m2/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.android.kt
@@ -1,0 +1,28 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
+
+@Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) {
+    val license = remember(library) {
+        library.htmlReadyLicenseContent.takeIf { it.isNotEmpty() }?.let { AnnotatedString.fromHtml(it) }
+    }
+    if (license != null) {
+        Text(
+            text = license,
+            modifier = modifier,
+            color = colors.contentColor
+        )
+    }
+}

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 
 /**
@@ -18,12 +19,14 @@ import com.mikepenz.aboutlibraries.entity.Library
 fun LibrariesContainer(
     aboutLibsJson: String,
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -32,17 +35,20 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val libs = Libs.Builder().withJson(aboutLibsJson).build()
     LibrariesContainer(
         libs,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -51,6 +57,7 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
     )
 }
 
@@ -61,12 +68,14 @@ fun LibrariesContainer(
 fun LibrariesContainer(
     librariesBlock: () -> Libs,
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -75,18 +84,21 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val libs = librariesBlock()
 
     LibrariesContainer(
         libraries = libs,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -95,5 +107,6 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
     )
 }

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
@@ -16,6 +16,7 @@ import com.mikepenz.aboutlibraries.entity.Library
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     aboutLibsJson: String,
@@ -38,11 +39,9 @@ fun LibrariesContainer(
     onLibraryClick: ((Library) -> Unit)? = null,
     onFundingClick: ((Funding) -> Unit)? = null,
 ) {
-    val libs = remember(aboutLibsJson) {
-        Libs.Builder().withJson(aboutLibsJson).build()
-    }
+    val libs by rememberLibraries(aboutLibsJson)
     LibrariesContainer(
-        libs,
+        libraries = libs,
         modifier = modifier,
         libraryModifier = libraryModifier,
         lazyListState = lazyListState,
@@ -67,6 +66,7 @@ fun LibrariesContainer(
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     librariesBlock: () -> Libs,

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Libraries.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
@@ -37,7 +38,9 @@ fun LibrariesContainer(
     onLibraryClick: ((Library) -> Unit)? = null,
     onFundingClick: ((Funding) -> Unit)? = null,
 ) {
-    val libs = Libs.Builder().withJson(aboutLibsJson).build()
+    val libs = remember(aboutLibsJson) {
+        Libs.Builder().withJson(aboutLibsJson).build()
+    }
     LibrariesContainer(
         libs,
         modifier = modifier,

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -82,6 +84,8 @@ fun LibrariesContainer(
             LibraryChip(
                 modifier = Modifier.padding(padding.versionPadding.containerPadding),
                 minHeight = dimensions.chipMinHeight,
+                backgroundColor = colors.versionChipColors.containerColor,
+                contentColor = colors.versionChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -122,8 +126,8 @@ fun LibrariesContainer(
             LibraryChip(
                 modifier = Modifier.padding(padding.licensePadding.containerPadding),
                 minHeight = dimensions.chipMinHeight,
-                backgroundColor = colors.badgeBackgroundColor,
-                contentColor = colors.badgeContentColor,
+                backgroundColor = colors.licenseChipColors.containerColor,
+                contentColor = colors.licenseChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -140,7 +144,7 @@ fun LibrariesContainer(
         if (showFundingBadges) {
             val uriHandler = LocalUriHandler.current
             LibraryChip(
-                modifier = Modifier.padding(padding.fundingPadding.containerPadding),
+                modifier = Modifier.padding(padding.fundingPadding.containerPadding).pointerHoverIcon(PointerIcon.Hand),
                 onClick = {
                     if (onFundingClick != null) {
                         onFundingClick(funding)
@@ -153,8 +157,8 @@ fun LibrariesContainer(
                     }
                 },
                 minHeight = dimensions.chipMinHeight,
-                backgroundColor = colors.fundingBadgeContentColor,
-                contentColor = colors.fundingBadgeBackgroundColor,
+                backgroundColor = colors.fundingChipColors.containerColor,
+                contentColor = colors.fundingChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -284,25 +288,62 @@ internal fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier
  * @param contentColor the content color of this [Library]
  * @param badgeBackgroundColor the badge background color of this [Library]
  * @param badgeContentColor the badge content color of this [Library]
- * @param fundingBadgeBackgroundColor the funding badge background color of this [Library]
- * @param fundingBadgeContentColor the funding badge content color of this [Library]
+ * @param dialogConfirmButtonColor the dialog's confirm button color of this [Library]
+ */
+@Deprecated("Use libraryColors() instead with `ChipColors` arguments.")
+@Composable
+fun LibraryDefaults.libraryColors(
+    backgroundColor: Color,
+    contentColor: Color = contentColorFor(backgroundColor),
+    badgeBackgroundColor: Color = MaterialTheme.colors.primary,
+    badgeContentColor: Color = contentColorFor(badgeBackgroundColor),
+    dialogConfirmButtonColor: Color = MaterialTheme.colors.primary,
+): LibraryColors = libraryColors(
+    backgroundColor = backgroundColor,
+    contentColor = contentColor,
+    versionChipColors = chipColors(containerColor = backgroundColor),
+    licenseChipColors = chipColors(badgeBackgroundColor, badgeContentColor),
+    dialogConfirmButtonColor = dialogConfirmButtonColor,
+)
+
+/**
+ * Creates a [LibraryColors] that represents the default colors used in a [Library].
+ *
+ * @param backgroundColor the background color of this [Library]
+ * @param contentColor the content color of this [Library]
+ * @param versionChipColors the colors used for the version chip
+ * @param licenseChipColors the colors used for the license chip
+ * @param fundingChipColors the colors used for the funding chip
  * @param dialogConfirmButtonColor the dialog's confirm button color of this [Library]
  */
 @Composable
 fun LibraryDefaults.libraryColors(
     backgroundColor: Color = MaterialTheme.colors.background,
     contentColor: Color = contentColorFor(backgroundColor),
-    badgeBackgroundColor: Color = MaterialTheme.colors.primary,
-    badgeContentColor: Color = contentColorFor(badgeBackgroundColor),
-    fundingBadgeBackgroundColor: Color = MaterialTheme.colors.secondary,
-    fundingBadgeContentColor: Color = contentColorFor(fundingBadgeBackgroundColor),
+    versionChipColors: ChipColors = chipColors(containerColor = backgroundColor),
+    licenseChipColors: ChipColors = chipColors(),
+    fundingChipColors: ChipColors = chipColors(
+        containerColor = MaterialTheme.colors.secondary,
+        contentColor = contentColorFor(MaterialTheme.colors.secondary),
+    ),
     dialogConfirmButtonColor: Color = MaterialTheme.colors.primary,
 ): LibraryColors = DefaultLibraryColors(
     backgroundColor = backgroundColor,
     contentColor = contentColor,
-    badgeBackgroundColor = badgeBackgroundColor,
-    badgeContentColor = badgeContentColor,
-    fundingBadgeBackgroundColor = fundingBadgeBackgroundColor,
-    fundingBadgeContentColor = fundingBadgeContentColor,
+    versionChipColors = versionChipColors,
+    licenseChipColors = licenseChipColors,
+    fundingChipColors = fundingChipColors,
     dialogConfirmButtonColor = dialogConfirmButtonColor,
+)
+
+/**
+ * Creates a [ChipColors] that represents the colors to use for a chip.
+ */
+@Composable
+fun LibraryDefaults.chipColors(
+    containerColor: Color = MaterialTheme.colors.primary,
+    contentColor: Color = contentColorFor(containerColor),
+): ChipColors = DefaultChipColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
 )

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
-import com.mikepenz.aboutlibraries.ui.compose.component.LibrariesChip
+import com.mikepenz.aboutlibraries.ui.compose.component.LibraryChip
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 import kotlinx.collections.immutable.persistentListOf
@@ -92,14 +92,13 @@ fun LibrariesContainer(
         },
         version = { version ->
             if (showVersion) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.versionPadding.containerPadding),
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.versionBadgePadding),
+                        modifier = Modifier.padding(padding.versionPadding.contentPadding),
                         text = version,
                         style = textStyles.versionTextStyle ?: typography.body2,
-                        color = colors.contentColor,
                         maxLines = textStyles.versionMaxLines,
                         textAlign = TextAlign.Center,
                         overflow = textStyles.defaultOverflow,
@@ -131,23 +130,25 @@ fun LibrariesContainer(
         },
         license = { license ->
             if (showLicenseBadges) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.licensePadding.containerPadding),
                     backgroundColor = colors.badgeBackgroundColor,
                     contentColor = colors.badgeContentColor,
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        modifier = Modifier.padding(padding.licensePadding.contentPadding),
                         text = license.name,
                         style = textStyles.licensesTextStyle ?: LocalTextStyle.current,
+                        textAlign = TextAlign.Center,
+                        overflow = textStyles.defaultOverflow,
                     )
                 }
             }
         },
         funding = { funding ->
             if (showFundingBadges) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.fundingPadding.containerPadding),
                     onClick = {
                         if (onFundingClick != null) {
                             onFundingClick(funding)
@@ -163,9 +164,11 @@ fun LibrariesContainer(
                     contentColor = colors.fundingBadgeBackgroundColor,
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        modifier = Modifier.padding(padding.fundingPadding.contentPadding),
                         text = funding.platform,
                         style = textStyles.fundingTextStyle ?: LocalTextStyle.current,
+                        textAlign = TextAlign.Center,
+                        overflow = textStyles.defaultOverflow,
                     )
                 }
             }
@@ -207,7 +210,6 @@ fun LicenseDialog(
     onDismiss: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(),

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -1,13 +1,11 @@
 package com.mikepenz.aboutlibraries.ui.compose
 
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyItemScope
@@ -15,9 +13,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Badge
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
@@ -30,7 +26,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
@@ -40,6 +35,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.component.LibrariesChip
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 import kotlinx.collections.immutable.persistentListOf
@@ -96,12 +92,11 @@ fun LibrariesContainer(
         },
         version = { version ->
             if (showVersion) {
-                Badge(
+                LibrariesChip(
                     modifier = Modifier.padding(padding.badgePadding),
-                    contentColor = MaterialTheme.colors.onSurface,
-                    backgroundColor = MaterialTheme.colors.surface,
                 ) {
                     Text(
+                        modifier = Modifier.padding(padding.versionBadgePadding),
                         text = version,
                         style = textStyles.versionTextStyle ?: typography.body2,
                         color = colors.contentColor,
@@ -136,10 +131,10 @@ fun LibrariesContainer(
         },
         license = { license ->
             if (showLicenseBadges) {
-                Badge(
+                LibrariesChip(
                     modifier = Modifier.padding(padding.badgePadding),
+                    backgroundColor = colors.badgeBackgroundColor,
                     contentColor = colors.badgeContentColor,
-                    backgroundColor = colors.badgeBackgroundColor
                 ) {
                     Text(
                         modifier = Modifier.padding(padding.badgeContentPadding),
@@ -151,23 +146,21 @@ fun LibrariesContainer(
         },
         funding = { funding ->
             if (showFundingBadges) {
-                Badge(
-                    modifier = Modifier
-                        .padding(padding.badgePadding)
-                        .clip(RoundedCornerShape(percent = 50))
-                        .clickable {
-                            if (onFundingClick != null) {
-                                onFundingClick(funding)
-                            } else {
-                                try {
-                                    uriHandler.openUri(funding.url)
-                                } catch (t: Throwable) {
-                                    println("Failed to open funding url: ${funding.url} // ${t.message}")
-                                }
+                LibrariesChip(
+                    modifier = Modifier.padding(padding.badgePadding),
+                    onClick = {
+                        if (onFundingClick != null) {
+                            onFundingClick(funding)
+                        } else {
+                            try {
+                                uriHandler.openUri(funding.url)
+                            } catch (t: Throwable) {
+                                println("Failed to open funding url: ${funding.url} // ${t.message}")
                             }
-                        },
-                    contentColor = colors.fundingBadgeContentColor,
-                    backgroundColor = colors.fundingBadgeBackgroundColor
+                        }
+                    },
+                    backgroundColor = colors.fundingBadgeContentColor,
+                    contentColor = colors.fundingBadgeBackgroundColor,
                 ) {
                     Text(
                         modifier = Modifier.padding(padding.badgeContentPadding),
@@ -205,7 +198,6 @@ fun LibrariesContainer(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LicenseDialog(
     library: Library,
@@ -221,7 +213,9 @@ fun LicenseDialog(
         properties = DialogProperties(),
         content = {
             Surface(
-                shape = MaterialTheme.shapes.medium, color = colors.backgroundColor, contentColor = colors.contentColor
+                shape = MaterialTheme.shapes.medium,
+                color = colors.backgroundColor,
+                contentColor = colors.contentColor
             ) {
                 Column {
                     val interactionSource = remember { MutableInteractionSource() }

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -175,7 +175,7 @@ fun LibrariesContainer(
     header: (LazyListScope.() -> Unit)? = null,
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
-    licenseDialogBody: (@Composable (Library) -> Unit)? = { library -> LicenseDialogBody(library, colors) },
+    licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, modifier -> LicenseDialogBody(library = library, colors = colors, modifier = modifier) },
     licenseDialogConfirmText: String = "OK",
 ) {
     val libs = libraries?.libraries ?: persistentListOf()
@@ -216,6 +216,7 @@ fun LibrariesContainer(
         LicenseDialog(
             library = library,
             colors = colors,
+            padding = padding,
             confirmText = licenseDialogConfirmText,
             body = licenseDialogBody
         ) {
@@ -228,8 +229,9 @@ fun LibrariesContainer(
 fun LicenseDialog(
     library: Library,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
+    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     confirmText: String = "OK",
-    body: @Composable (Library) -> Unit,
+    body: @Composable (Library, Modifier) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -240,7 +242,8 @@ fun LicenseDialog(
             Surface(
                 shape = MaterialTheme.shapes.medium,
                 color = colors.backgroundColor,
-                contentColor = colors.contentColor
+                contentColor = colors.contentColor,
+                modifier = Modifier.padding(8.dp),
             ) {
                 Column {
                     val interactionSource = remember { MutableInteractionSource() }
@@ -249,10 +252,9 @@ fun LicenseDialog(
                             .indication(interactionSource, LocalIndication.current)
                             .focusable(interactionSource = interactionSource)
                             .verticalScroll(scrollState)
-                            .padding(8.dp)
-                            .weight(1f)
+                            .weight(1f, fill = false)
                     ) {
-                        body(library)
+                        body(library, Modifier.padding(padding.licenseDialogContentPadding))
                     }
                     TextButton(
                         modifier = Modifier.align(Alignment.End).padding(horizontal = 8.dp, vertical = 4.dp),
@@ -270,7 +272,10 @@ fun LicenseDialog(
 }
 
 @Composable
-internal fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier) {
+expect fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier)
+
+@Composable
+internal fun DefaultLicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier) {
     val license = remember(library) { library.strippedLicenseContent.takeIf { it.isNotEmpty() } }
     if (license != null) {
         Text(

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
@@ -1,0 +1,77 @@
+package com.mikepenz.aboutlibraries.ui.compose.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Surface
+import androidx.compose.material.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LibrariesChip(
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource? = null,
+    shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),
+    border: BorderStroke? = null,
+    backgroundColor: Color = MaterialTheme.colors.onSurface
+        .copy(alpha = SurfaceOverlayOpacity)
+        .compositeOver(MaterialTheme.colors.surface),
+    contentColor: Color = MaterialTheme.colors.onSurface.copy(alpha = ContentOpacity),
+    minHeight: Dp = 16.dp,
+    onClick: (() -> Unit)? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Surface(
+        modifier = modifier
+            .clip(shape)
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(
+                        interactionSource = interactionSource,
+                        indication = ripple(),
+                        onClick = onClick
+                    )
+                } else Modifier
+            )
+            .semantics { role = Role.Button },
+        shape = shape,
+        color = backgroundColor,
+        contentColor = contentColor,
+        border = border,
+    ) {
+        CompositionLocalProvider(LocalContentAlpha provides contentColor.alpha) {
+            ProvideTextStyle(value = MaterialTheme.typography.body2) {
+                Row(
+                    Modifier.defaultMinSize(minHeight = minHeight),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+}
+
+private const val ContentOpacity = 0.87f
+private const val SurfaceOverlayOpacity = 0.12f

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun LibrariesChip(
+internal fun LibraryChip(
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
     shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),

--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/component/LibrariesChip.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-internal fun LibraryChip(
+fun LibraryChip(
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
     shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),

--- a/aboutlibraries-compose-m2/src/jsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.js.kt
+++ b/aboutlibraries-compose-m2/src/jsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.js.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+
+@Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m2/src/jvmMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.jvm.kt
+++ b/aboutlibraries-compose-m2/src/jvmMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.jvm.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+
+@Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m2/src/nativeMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.native.kt
+++ b/aboutlibraries-compose-m2/src/nativeMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.native.kt
@@ -1,0 +1,15 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+
+@androidx.compose.runtime.Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m2/src/wasmJsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.wasmJs.kt
+++ b/aboutlibraries-compose-m2/src/wasmJsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.wasmJs.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+
+@Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
@@ -33,6 +34,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibrariesContainer(
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     librariesBlock: (Context) -> Libs = { context ->
         Libs.Builder().withContext(context).build()
     },
@@ -42,6 +44,7 @@ fun LibrariesContainer(
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -50,6 +53,7 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -61,12 +65,14 @@ fun LibrariesContainer(
     LibrariesContainer(
         libraries = libraries.value,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -75,9 +81,12 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
         licenseDialogBody = { library ->
             val license = remember(library) {
-                library.htmlReadyLicenseContent.takeIf { it.isNotEmpty() }?.let { AnnotatedString.fromHtml(it) }
+                library.htmlReadyLicenseContent
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { AnnotatedString.fromHtml(it) }
             }
             if (license != null) {
                 Text(

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
@@ -6,15 +6,11 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Funding
@@ -24,7 +20,6 @@ import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDimensions
 import com.mikepenz.aboutlibraries.ui.compose.LibraryPadding
 import com.mikepenz.aboutlibraries.ui.compose.LibraryTextStyles
-import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.util.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -32,6 +27,7 @@ import kotlinx.coroutines.withContext
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     modifier: Modifier = Modifier,
@@ -83,18 +79,8 @@ fun LibrariesContainer(
         footer = footer,
         onLibraryClick = onLibraryClick,
         onFundingClick = onFundingClick,
-        licenseDialogBody = { library ->
-            val license = remember(library) {
-                library.htmlReadyLicenseContent
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { AnnotatedString.fromHtml(it) }
-            }
-            if (license != null) {
-                Text(
-                    text = license,
-                    color = colors.contentColor
-                )
-            }
+        licenseDialogBody = { library, modifier ->
+            LicenseDialogBody(library, colors, modifier)
         }
     )
 }

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/AndroidLibraries.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -57,13 +58,13 @@ fun LibrariesContainer(
 ) {
     val context = LocalContext.current
 
-    val libraries = produceState<Libs?>(null) {
+    val libraries by produceState<Libs?>(null) {
         value = withContext(Dispatchers.IO) {
             librariesBlock(context)
         }
     }
     LibrariesContainer(
-        libraries = libraries.value,
+        libraries = libraries,
         modifier = modifier,
         libraryModifier = libraryModifier,
         lazyListState = lazyListState,

--- a/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.android.kt
+++ b/aboutlibraries-compose-m3/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.android.kt
@@ -1,0 +1,31 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
+import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
+
+@Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) {
+    val license = remember(library) {
+        library.htmlReadyLicenseContent
+            .takeIf { it.isNotEmpty() }
+            ?.let { AnnotatedString.fromHtml(it) }
+    }
+    if (license != null) {
+        Text(
+            text = license,
+            modifier = modifier,
+            color = colors.contentColor
+        )
+    }
+}

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
@@ -42,7 +43,9 @@ fun LibrariesContainer(
     onLibraryClick: ((Library) -> Unit)? = null,
     onFundingClick: ((Funding) -> Unit)? = null,
 ) {
-    val libs = Libs.Builder().withJson(aboutLibsJson).build()
+    val libs = remember(aboutLibsJson) {
+        Libs.Builder().withJson(aboutLibsJson).build()
+    }
     LibrariesContainer(
         libs,
         modifier = modifier,

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
@@ -24,12 +25,14 @@ import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 fun LibrariesContainer(
     aboutLibsJson: String,
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -37,17 +40,20 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val libs = Libs.Builder().withJson(aboutLibsJson).build()
     LibrariesContainer(
         libs,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -55,6 +61,7 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
     )
 }
 
@@ -65,12 +72,14 @@ fun LibrariesContainer(
 fun LibrariesContainer(
     librariesBlock: () -> Libs,
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -79,18 +88,20 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
 ) {
     val libs = librariesBlock()
-
     LibrariesContainer(
         libraries = libs,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
         showAuthor = showAuthor,
         showDescription = showDescription,
         showVersion = showVersion,
         showLicenseBadges = showLicenseBadges,
+        showFundingBadges = showFundingBadges,
         colors = colors,
         padding = padding,
         dimensions = dimensions,
@@ -99,6 +110,7 @@ fun LibrariesContainer(
         divider = divider,
         footer = footer,
         onLibraryClick = onLibraryClick,
+        onFundingClick = onFundingClick,
     )
 }
 

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/Libraries.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
@@ -22,6 +22,7 @@ import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     aboutLibsJson: String,
@@ -43,11 +44,9 @@ fun LibrariesContainer(
     onLibraryClick: ((Library) -> Unit)? = null,
     onFundingClick: ((Funding) -> Unit)? = null,
 ) {
-    val libs = remember(aboutLibsJson) {
-        Libs.Builder().withJson(aboutLibsJson).build()
-    }
+    val libs by rememberLibraries(aboutLibsJson)
     LibrariesContainer(
-        libs,
+        libraries = libs,
         modifier = modifier,
         libraryModifier = libraryModifier,
         lazyListState = lazyListState,
@@ -71,6 +70,7 @@ fun LibrariesContainer(
 /**
  * Displays all provided libraries in a simple list.
  */
+@Deprecated("Use `LibrariesContainer` variant with `Libs` instead. Use `rememberLibraries` to load the libraries.")
 @Composable
 fun LibrariesContainer(
     librariesBlock: () -> Libs,
@@ -116,25 +116,3 @@ fun LibrariesContainer(
         onFundingClick = onFundingClick,
     )
 }
-
-/**
- * Creates a State<Libs?> that holds the [Libs] as loaded by the [libraries].
- *
- * @see Libs
- */
-@Deprecated("Use rememberLibraries(libraries: ByteArray) instead", ReplaceWith("com.mikepenz.aboutlibraries.ui.compose.rememberLibraries(libraries)"))
-@Composable
-fun rememberLibraries(
-    libraries: ByteArray,
-) = rememberLibraries(libraries)
-
-/**
- * Creates a State<Libs?> that holds the [Libs] as loaded by the [block].
- *
- * @see Libs
- */
-@Deprecated("Use rememberLibraries(block: suspend () -> String) instead", ReplaceWith("com.mikepenz.aboutlibraries.ui.compose.rememberLibraries(block)"))
-@Composable
-fun rememberLibraries(
-    block: suspend () -> String,
-) = rememberLibraries(block)

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -40,6 +42,8 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.ui.compose.ChipColors
+import com.mikepenz.aboutlibraries.ui.compose.DefaultChipColors
 import com.mikepenz.aboutlibraries.ui.compose.DefaultLibraryColors
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesScaffold
 import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
@@ -91,6 +95,8 @@ fun LibrariesContainer(
             LibraryChip(
                 modifier = Modifier.padding(padding.versionPadding.containerPadding),
                 minHeight = dimensions.chipMinHeight,
+                containerColor = colors.versionChipColors.containerColor,
+                contentColor = colors.versionChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -131,8 +137,8 @@ fun LibrariesContainer(
             LibraryChip(
                 modifier = Modifier.padding(padding.licensePadding.containerPadding),
                 minHeight = dimensions.chipMinHeight,
-                contentColor = colors.badgeContentColor,
-                containerColor = colors.badgeBackgroundColor,
+                containerColor = colors.licenseChipColors.containerColor,
+                contentColor = colors.licenseChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -150,7 +156,7 @@ fun LibrariesContainer(
         if (showFundingBadges) {
             val uriHandler = LocalUriHandler.current
             LibraryChip(
-                modifier = Modifier.padding(padding.fundingPadding.containerPadding),
+                modifier = Modifier.padding(padding.fundingPadding.containerPadding).pointerHoverIcon(PointerIcon.Hand),
                 onClick = {
                     if (onFundingClick != null) {
                         onFundingClick(funding)
@@ -163,8 +169,8 @@ fun LibrariesContainer(
                     }
                 },
                 minHeight = dimensions.chipMinHeight,
-                contentColor = colors.fundingBadgeContentColor,
-                containerColor = colors.fundingBadgeBackgroundColor,
+                containerColor = colors.fundingChipColors.containerColor,
+                contentColor = colors.fundingChipColors.contentColor,
                 shape = shapes.chipShape,
             ) {
                 Text(
@@ -300,25 +306,62 @@ internal fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier
  * @param contentColor the content color of this [Library]
  * @param badgeBackgroundColor the badge background color of this [Library]
  * @param badgeContentColor the badge content color of this [Library]
- * @param fundingBadgeBackgroundColor the funding badge background color of this [Library]
- * @param fundingBadgeContentColor the funding badge content color of this [Library]
+ * @param dialogConfirmButtonColor the dialog's confirm button color of this [Library]
+ */
+@Deprecated("Use libraryColors() instead with `ChipColors` arguments.")
+@Composable
+fun LibraryDefaults.libraryColors(
+    backgroundColor: Color,
+    contentColor: Color = contentColorFor(backgroundColor),
+    badgeBackgroundColor: Color = MaterialTheme.colorScheme.primary,
+    badgeContentColor: Color = contentColorFor(badgeBackgroundColor),
+    dialogConfirmButtonColor: Color = MaterialTheme.colorScheme.primary,
+): LibraryColors = libraryColors(
+    backgroundColor = backgroundColor,
+    contentColor = contentColor,
+    versionChipColors = chipColors(containerColor = backgroundColor),
+    licenseChipColors = chipColors(badgeBackgroundColor, badgeContentColor),
+    dialogConfirmButtonColor = dialogConfirmButtonColor,
+)
+
+/**
+ * Creates a [LibraryColors] that represents the default colors used in a [Library].
+ *
+ * @param backgroundColor the background color of this [Library]
+ * @param contentColor the content color of this [Library]
+ * @param versionChipColors the colors used for the version chip
+ * @param licenseChipColors the colors used for the license chip
+ * @param fundingChipColors the colors used for the funding chip
  * @param dialogConfirmButtonColor the dialog's confirm button color of this [Library]
  */
 @Composable
 fun LibraryDefaults.libraryColors(
     backgroundColor: Color = MaterialTheme.colorScheme.background,
     contentColor: Color = contentColorFor(backgroundColor),
-    badgeBackgroundColor: Color = MaterialTheme.colorScheme.primary,
-    badgeContentColor: Color = contentColorFor(badgeBackgroundColor),
-    fundingBadgeBackgroundColor: Color = MaterialTheme.colorScheme.secondary,
-    fundingBadgeContentColor: Color = contentColorFor(fundingBadgeBackgroundColor),
+    versionChipColors: ChipColors = chipColors(containerColor = backgroundColor),
+    licenseChipColors: ChipColors = chipColors(),
+    fundingChipColors: ChipColors = chipColors(
+        containerColor = MaterialTheme.colorScheme.secondary,
+        contentColor = contentColorFor(MaterialTheme.colorScheme.secondary),
+    ),
     dialogConfirmButtonColor: Color = MaterialTheme.colorScheme.primary,
 ): LibraryColors = DefaultLibraryColors(
     backgroundColor = backgroundColor,
     contentColor = contentColor,
-    badgeBackgroundColor = badgeBackgroundColor,
-    badgeContentColor = badgeContentColor,
-    fundingBadgeBackgroundColor = fundingBadgeBackgroundColor,
-    fundingBadgeContentColor = fundingBadgeContentColor,
+    versionChipColors = versionChipColors,
+    licenseChipColors = licenseChipColors,
+    fundingChipColors = fundingChipColors,
     dialogConfirmButtonColor = dialogConfirmButtonColor,
+)
+
+/**
+ * Creates a [ChipColors] that represents the colors to use for a chip.
+ */
+@Composable
+fun LibraryDefaults.chipColors(
+    containerColor: Color = MaterialTheme.colorScheme.primary,
+    contentColor: Color = contentColorFor(containerColor),
+): ChipColors = DefaultChipColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
 )

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -188,7 +188,7 @@ fun LibrariesContainer(
     header: (LazyListScope.() -> Unit)? = null,
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
-    licenseDialogBody: (@Composable (Library) -> Unit)? = { library -> LicenseDialogBody(library = library, colors = colors) },
+    licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, modifier -> LicenseDialogBody(library = library, colors = colors, modifier = modifier) },
     licenseDialogConfirmText: String = "OK",
 ) {
     val libs = libraries?.libraries ?: persistentListOf()
@@ -229,6 +229,7 @@ fun LibrariesContainer(
         LicenseDialog(
             library = library,
             colors = colors,
+            padding = padding,
             confirmText = licenseDialogConfirmText,
             body = licenseDialogBody
         ) {
@@ -242,8 +243,9 @@ fun LibrariesContainer(
 fun LicenseDialog(
     library: Library,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
+    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     confirmText: String = "OK",
-    body: @Composable (Library) -> Unit,
+    body: @Composable (Library, Modifier) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -255,19 +257,20 @@ fun LicenseDialog(
             Surface(
                 shape = MaterialTheme.shapes.medium,
                 color = colors.backgroundColor,
-                contentColor = colors.contentColor
+                contentColor = colors.contentColor,
+                modifier = Modifier.padding(8.dp),
             ) {
                 Column {
                     val interactionSource = remember { MutableInteractionSource() }
+
                     Box(
                         modifier = Modifier
                             .indication(interactionSource, LocalIndication.current)
                             .focusable(interactionSource = interactionSource)
+                            .weight(1f, fill = false)
                             .verticalScroll(scrollState)
-                            .padding(8.dp)
-                            .weight(1f)
                     ) {
-                        body(library)
+                        body(library, Modifier.padding(padding.licenseDialogContentPadding))
                     }
                     TextButton(
                         modifier = Modifier
@@ -287,7 +290,10 @@ fun LicenseDialog(
 }
 
 @Composable
-internal fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier) {
+expect fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier)
+
+@Composable
+internal fun DefaultLicenseDialogBody(library: Library, colors: LibraryColors, modifier: Modifier = Modifier) {
     val license = remember(library) { library.strippedLicenseContent.takeIf { it.isNotEmpty() } }
     if (license != null) {
         Text(

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -1,7 +1,6 @@
 package com.mikepenz.aboutlibraries.ui.compose.m3
 
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -15,9 +14,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Badge
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -30,7 +27,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
@@ -47,6 +43,7 @@ import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDimensions
 import com.mikepenz.aboutlibraries.ui.compose.LibraryPadding
 import com.mikepenz.aboutlibraries.ui.compose.LibraryTextStyles
+import com.mikepenz.aboutlibraries.ui.compose.m3.component.LibrariesChip
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 import kotlinx.collections.immutable.persistentListOf
@@ -103,12 +100,11 @@ fun LibrariesContainer(
         },
         version = { version ->
             if (showVersion) {
-                Badge(
+                LibrariesChip(
                     modifier = Modifier.padding(padding.badgePadding),
-                    contentColor = MaterialTheme.colorScheme.onSurface,
-                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
                 ) {
                     Text(
+                        modifier = Modifier.padding(padding.versionBadgePadding),
                         text = version,
                         style = textStyles.versionTextStyle ?: typography.bodyMedium,
                         color = colors.contentColor,
@@ -143,7 +139,7 @@ fun LibrariesContainer(
         },
         license = { license ->
             if (showLicenseBadges) {
-                Badge(
+                LibrariesChip(
                     modifier = Modifier.padding(padding.badgePadding),
                     contentColor = colors.badgeContentColor,
                     containerColor = colors.badgeBackgroundColor
@@ -159,21 +155,19 @@ fun LibrariesContainer(
         },
         funding = { funding ->
             if (showFundingBadges) {
-                Badge(
-                    modifier = Modifier
-                        .padding(padding.badgePadding)
-                        .clip(RoundedCornerShape(percent = 50))
-                        .clickable {
-                            if (onFundingClick != null) {
-                                onFundingClick(funding)
-                            } else {
-                                try {
-                                    uriHandler.openUri(funding.url)
-                                } catch (t: Throwable) {
-                                    println("Failed to open funding url: ${funding.url} // ${t.message}")
-                                }
+                LibrariesChip(
+                    modifier = Modifier.padding(padding.badgePadding),
+                    onClick = {
+                        if (onFundingClick != null) {
+                            onFundingClick(funding)
+                        } else {
+                            try {
+                                uriHandler.openUri(funding.url)
+                            } catch (t: Throwable) {
+                                println("Failed to open funding url: ${funding.url} // ${t.message}")
                             }
-                        },
+                        }
+                    },
                     contentColor = colors.fundingBadgeContentColor,
                     containerColor = colors.fundingBadgeBackgroundColor
                 ) {

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -43,7 +43,7 @@ import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDimensions
 import com.mikepenz.aboutlibraries.ui.compose.LibraryPadding
 import com.mikepenz.aboutlibraries.ui.compose.LibraryTextStyles
-import com.mikepenz.aboutlibraries.ui.compose.m3.component.LibrariesChip
+import com.mikepenz.aboutlibraries.ui.compose.m3.component.LibraryChip
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 import kotlinx.collections.immutable.persistentListOf
@@ -100,14 +100,13 @@ fun LibrariesContainer(
         },
         version = { version ->
             if (showVersion) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.versionPadding.containerPadding),
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.versionBadgePadding),
+                        modifier = Modifier.padding(padding.versionPadding.contentPadding),
                         text = version,
                         style = textStyles.versionTextStyle ?: typography.bodyMedium,
-                        color = colors.contentColor,
                         maxLines = textStyles.versionMaxLines,
                         textAlign = TextAlign.Center,
                         overflow = textStyles.defaultOverflow,
@@ -139,24 +138,26 @@ fun LibrariesContainer(
         },
         license = { license ->
             if (showLicenseBadges) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.licensePadding.containerPadding),
                     contentColor = colors.badgeContentColor,
                     containerColor = colors.badgeBackgroundColor
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        modifier = Modifier.padding(padding.licensePadding.contentPadding),
                         maxLines = 1,
                         text = license.name,
                         style = textStyles.licensesTextStyle ?: LocalTextStyle.current,
+                        textAlign = TextAlign.Center,
+                        overflow = textStyles.defaultOverflow,
                     )
                 }
             }
         },
         funding = { funding ->
             if (showFundingBadges) {
-                LibrariesChip(
-                    modifier = Modifier.padding(padding.badgePadding),
+                LibraryChip(
+                    modifier = Modifier.padding(padding.fundingPadding.containerPadding),
                     onClick = {
                         if (onFundingClick != null) {
                             onFundingClick(funding)
@@ -172,10 +173,12 @@ fun LibrariesContainer(
                     containerColor = colors.fundingBadgeBackgroundColor
                 ) {
                     Text(
-                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        modifier = Modifier.padding(padding.fundingPadding.contentPadding),
                         maxLines = 1,
                         text = funding.platform,
                         style = textStyles.fundingTextStyle ?: LocalTextStyle.current,
+                        textAlign = TextAlign.Center,
+                        overflow = textStyles.defaultOverflow,
                     )
                 }
             }

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -1,41 +1,36 @@
 package com.mikepenz.aboutlibraries.ui.compose.m3
 
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Badge
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.Typography
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
@@ -43,18 +38,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Funding
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.DefaultLibraryColors
+import com.mikepenz.aboutlibraries.ui.compose.LibrariesScaffold
 import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDimensions
 import com.mikepenz.aboutlibraries.ui.compose.LibraryPadding
 import com.mikepenz.aboutlibraries.ui.compose.LibraryTextStyles
-import com.mikepenz.aboutlibraries.ui.compose.layout.LibraryScaffoldLayout
-import com.mikepenz.aboutlibraries.ui.compose.util.author
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 
@@ -65,12 +59,14 @@ import kotlinx.collections.immutable.persistentListOf
 fun LibrariesContainer(
     libraries: Libs?,
     modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     showAuthor: Boolean = true,
     showDescription: Boolean = false,
     showVersion: Boolean = true,
     showLicenseBadges: Boolean = true,
+    showFundingBadges: Boolean = false,
     colors: LibraryColors = LibraryDefaults.libraryColors(),
     padding: LibraryPadding = LibraryDefaults.libraryPadding(),
     dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
@@ -79,27 +75,117 @@ fun LibrariesContainer(
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
     onLibraryClick: ((Library) -> Unit)? = null,
+    onFundingClick: ((Funding) -> Unit)? = null,
     licenseDialogBody: (@Composable (Library) -> Unit)? = { library -> LicenseDialogBody(library = library, colors = colors) },
     licenseDialogConfirmText: String = "OK",
 ) {
     val uriHandler = LocalUriHandler.current
-
+    val typography = MaterialTheme.typography
     val libs = libraries?.libraries ?: persistentListOf()
     val openDialog = remember { mutableStateOf<Library?>(null) }
 
-    Libraries(
+    LibrariesScaffold(
         libraries = libs,
         modifier = modifier,
+        libraryModifier = libraryModifier,
         lazyListState = lazyListState,
         contentPadding = contentPadding,
-        showAuthor = showAuthor,
-        showDescription = showDescription,
-        showVersion = showVersion,
-        showLicenseBadges = showLicenseBadges,
-        colors = colors,
         padding = padding,
         dimensions = dimensions,
-        textStyles = textStyles,
+        name = { libraryName ->
+            Text(
+                text = libraryName,
+                style = textStyles.nameTextStyle ?: typography.titleLarge,
+                color = colors.contentColor,
+                maxLines = textStyles.nameMaxLines,
+                overflow = textStyles.nameOverflow,
+            )
+        },
+        version = { version ->
+            if (showVersion) {
+                Badge(
+                    modifier = Modifier.padding(padding.badgePadding),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                ) {
+                    Text(
+                        text = version,
+                        style = textStyles.versionTextStyle ?: typography.bodyMedium,
+                        color = colors.contentColor,
+                        maxLines = textStyles.versionMaxLines,
+                        textAlign = TextAlign.Center,
+                        overflow = textStyles.defaultOverflow,
+                    )
+                }
+            }
+        },
+        author = { author ->
+            if (showAuthor && author.isNotBlank()) {
+                Text(
+                    text = author,
+                    style = textStyles.authorTextStyle ?: typography.bodyMedium,
+                    color = colors.contentColor,
+                    maxLines = textStyles.authorMaxLines,
+                    overflow = textStyles.defaultOverflow,
+                )
+            }
+        },
+        description = { description ->
+            if (showDescription) {
+                Text(
+                    text = description,
+                    style = textStyles.descriptionTextStyle ?: typography.bodySmall,
+                    color = colors.contentColor,
+                    maxLines = textStyles.descriptionMaxLines,
+                    overflow = textStyles.defaultOverflow,
+                )
+            }
+        },
+        license = { license ->
+            if (showLicenseBadges) {
+                Badge(
+                    modifier = Modifier.padding(padding.badgePadding),
+                    contentColor = colors.badgeContentColor,
+                    containerColor = colors.badgeBackgroundColor
+                ) {
+                    Text(
+                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        maxLines = 1,
+                        text = license.name,
+                        style = textStyles.licensesTextStyle ?: LocalTextStyle.current,
+                    )
+                }
+            }
+        },
+        funding = { funding ->
+            if (showFundingBadges) {
+                Badge(
+                    modifier = Modifier
+                        .padding(padding.badgePadding)
+                        .clip(RoundedCornerShape(percent = 50))
+                        .clickable {
+                            if (onFundingClick != null) {
+                                onFundingClick(funding)
+                            } else {
+                                try {
+                                    uriHandler.openUri(funding.url)
+                                } catch (t: Throwable) {
+                                    println("Failed to open funding url: ${funding.url} // ${t.message}")
+                                }
+                            }
+                        },
+                    contentColor = colors.fundingBadgeContentColor,
+                    containerColor = colors.fundingBadgeBackgroundColor
+                ) {
+                    Text(
+                        modifier = Modifier.padding(padding.badgeContentPadding),
+                        maxLines = 1,
+                        text = funding.platform,
+                        style = textStyles.fundingTextStyle ?: LocalTextStyle.current,
+                    )
+                }
+            }
+        },
         header = header,
         divider = divider,
         footer = footer,
@@ -107,23 +193,22 @@ fun LibrariesContainer(
             val license = library.licenses.firstOrNull()
             if (onLibraryClick != null) {
                 onLibraryClick(library)
+                true
             } else if (!license?.htmlReadyLicenseContent.isNullOrBlank()) {
                 openDialog.value = library
-            } else if (!license?.url.isNullOrBlank()) {
-                license.url?.also {
-                    try {
-                        uriHandler.openUri(it)
-                    } catch (t: Throwable) {
-                        println("Failed to open url: ${it}")
-                    }
-                }
-            }
+                true
+            } else false
         },
     )
 
     val library = openDialog.value
     if (library != null && licenseDialogBody != null) {
-        LicenseDialog(library, colors, licenseDialogConfirmText, body = licenseDialogBody) {
+        LicenseDialog(
+            library = library,
+            colors = colors,
+            confirmText = licenseDialogConfirmText,
+            body = licenseDialogBody
+        ) {
             openDialog.value = null
         }
     }
@@ -191,183 +276,6 @@ internal fun LicenseDialogBody(library: Library, colors: LibraryColors, modifier
 }
 
 /**
- * Displays all provided libraries in a simple list.
- */
-@Composable
-fun Libraries(
-    libraries: ImmutableList<Library>,
-    modifier: Modifier = Modifier,
-    lazyListState: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(0.dp),
-    showAuthor: Boolean = true,
-    showDescription: Boolean = false,
-    showVersion: Boolean = true,
-    showLicenseBadges: Boolean = true,
-    colors: LibraryColors = LibraryDefaults.libraryColors(),
-    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
-    dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
-    textStyles: LibraryTextStyles = LibraryDefaults.libraryTextStyles(),
-    header: (LazyListScope.() -> Unit)? = null,
-    divider: (@Composable LazyItemScope.() -> Unit)? = null,
-    footer: (LazyListScope.() -> Unit)? = null,
-    onLibraryClick: ((Library) -> Unit)? = null,
-) {
-    val uriHandler = LocalUriHandler.current
-
-    LazyColumn(
-        modifier,
-        verticalArrangement = Arrangement.spacedBy(dimensions.itemSpacing),
-        state = lazyListState,
-        contentPadding = contentPadding
-    ) {
-        header?.invoke(this)
-        libraryItems(
-            libraries = libraries,
-            showAuthor = showAuthor,
-            showDescription = showDescription,
-            showVersion = showVersion,
-            showLicenseBadges = showLicenseBadges,
-            colors = colors,
-            padding = padding,
-            textStyles = textStyles,
-            divider = divider,
-        ) { library ->
-            val license = library.licenses.firstOrNull()
-            if (onLibraryClick != null) {
-                onLibraryClick.invoke(library)
-            } else if (!license?.url.isNullOrBlank()) {
-                license.url?.also {
-                    try {
-                        uriHandler.openUri(it)
-                    } catch (t: Throwable) {
-                        println("Failed to open url: ${it}")
-                    }
-                }
-            }
-        }
-        footer?.invoke(this)
-    }
-}
-
-internal inline fun LazyListScope.libraryItems(
-    libraries: ImmutableList<Library>,
-    showAuthor: Boolean = true,
-    showDescription: Boolean = false,
-    showVersion: Boolean = true,
-    showLicenseBadges: Boolean = true,
-    colors: LibraryColors,
-    padding: LibraryPadding,
-    textStyles: LibraryTextStyles,
-    noinline divider: (@Composable LazyItemScope.() -> Unit)?,
-    crossinline onLibraryClick: ((Library) -> Unit),
-) {
-    itemsIndexed(libraries) { index, library ->
-        Library(
-            library = library,
-            showAuthor = showAuthor,
-            showDescription = showDescription,
-            showVersion = showVersion,
-            showLicenseBadges = showLicenseBadges,
-            colors = colors,
-            padding = padding,
-            textStyles = textStyles,
-        ) {
-            onLibraryClick.invoke(library)
-        }
-
-        if (divider != null && index < libraries.lastIndex) {
-            divider.invoke(this)
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
-@Composable
-fun Library(
-    library: Library,
-    showAuthor: Boolean = true,
-    showDescription: Boolean = false,
-    showVersion: Boolean = true,
-    showLicenseBadges: Boolean = true,
-    colors: LibraryColors = LibraryDefaults.libraryColors(),
-    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
-    textStyles: LibraryTextStyles = LibraryDefaults.libraryTextStyles(),
-    typography: Typography = MaterialTheme.typography,
-    onClick: () -> Unit,
-) {
-    LibraryScaffoldLayout(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(colors.backgroundColor)
-            .clickable { onClick.invoke() },
-        libraryPadding = padding,
-        name = {
-            Text(
-                text = library.name,
-                style = textStyles.nameTextStyle ?: typography.titleLarge,
-                color = colors.contentColor,
-                maxLines = textStyles.nameMaxLines,
-                overflow = textStyles.nameOverflow,
-            )
-        },
-        version = {
-            val version = library.artifactVersion
-            if (version != null && showVersion) {
-                Text(
-                    text = version,
-                    style = textStyles.versionTextStyle ?: typography.bodyMedium,
-                    color = colors.contentColor,
-                    maxLines = textStyles.versionMaxLines,
-                    textAlign = TextAlign.Center,
-                    overflow = textStyles.defaultOverflow,
-                )
-            }
-        },
-        author = {
-            val author = library.author
-            if (showAuthor && author.isNotBlank()) {
-                Text(
-                    text = author,
-                    style = textStyles.authorTextStyle ?: typography.bodyMedium,
-                    color = colors.contentColor,
-                    maxLines = textStyles.authorMaxLines,
-                    overflow = textStyles.defaultOverflow,
-                )
-            }
-        },
-        description = {
-            val description = library.description
-            if (showDescription && !description.isNullOrBlank()) {
-                Text(
-                    text = description,
-                    style = textStyles.descriptionTextStyle ?: typography.bodySmall,
-                    color = colors.contentColor,
-                    maxLines = textStyles.descriptionMaxLines,
-                    overflow = textStyles.defaultOverflow,
-                )
-            }
-        },
-        licenses = {
-            if (showLicenseBadges && library.licenses.isNotEmpty()) {
-                library.licenses.forEach {
-                    Badge(
-                        modifier = Modifier.padding(padding.badgePadding),
-                        contentColor = colors.badgeContentColor,
-                        containerColor = colors.badgeBackgroundColor
-                    ) {
-                        Text(
-                            modifier = Modifier.padding(padding.badgeContentPadding),
-                            text = it.name,
-                            style = textStyles.licensesTextStyle ?: LocalTextStyle.current,
-                        )
-                    }
-                }
-            }
-        },
-    )
-}
-
-/**
  * Creates a [LibraryColors] that represents the default colors used in
  * a [Library].
  *
@@ -375,6 +283,8 @@ fun Library(
  * @param contentColor the content color of this [Library]
  * @param badgeBackgroundColor the badge background color of this [Library]
  * @param badgeContentColor the badge content color of this [Library]
+ * @param fundingBadgeBackgroundColor the funding badge background color of this [Library]
+ * @param fundingBadgeContentColor the funding badge content color of this [Library]
  * @param dialogConfirmButtonColor the dialog's confirm button color of this [Library]
  */
 @Composable
@@ -383,11 +293,15 @@ fun LibraryDefaults.libraryColors(
     contentColor: Color = contentColorFor(backgroundColor),
     badgeBackgroundColor: Color = MaterialTheme.colorScheme.primary,
     badgeContentColor: Color = contentColorFor(badgeBackgroundColor),
+    fundingBadgeBackgroundColor: Color = MaterialTheme.colorScheme.secondary,
+    fundingBadgeContentColor: Color = contentColorFor(fundingBadgeBackgroundColor),
     dialogConfirmButtonColor: Color = MaterialTheme.colorScheme.primary,
 ): LibraryColors = DefaultLibraryColors(
     backgroundColor = backgroundColor,
     contentColor = contentColor,
     badgeBackgroundColor = badgeBackgroundColor,
     badgeContentColor = badgeContentColor,
+    fundingBadgeBackgroundColor = fundingBadgeBackgroundColor,
+    fundingBadgeContentColor = fundingBadgeContentColor,
     dialogConfirmButtonColor = dialogConfirmButtonColor,
 )

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun LibrariesChip(
+internal fun LibraryChip(
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
     shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
@@ -1,0 +1,73 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LibrariesChip(
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource? = null,
+    shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),
+    border: BorderStroke? = null,
+    containerColor: Color = MaterialTheme.colorScheme.onSurface
+        .copy(alpha = SurfaceOverlayOpacity)
+        .compositeOver(MaterialTheme.colorScheme.surface),
+    contentColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentOpacity),
+    minHeight: Dp = 16.dp,
+    onClick: (() -> Unit)? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Surface(
+        modifier = modifier
+            .clip(shape)
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(
+                        interactionSource = interactionSource,
+                        indication = ripple(),
+                        onClick = onClick
+                    )
+                } else Modifier
+            )
+            .semantics { role = Role.Button },
+        shape = shape,
+        color = containerColor,
+        contentColor = contentColor,
+        border = border,
+    ) {
+        ProvideTextStyle(value = MaterialTheme.typography.labelLarge) {
+            Row(
+                Modifier.defaultMinSize(minHeight = minHeight),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+private const val ContentOpacity = 0.87f
+private const val SurfaceOverlayOpacity = 0.12f

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/component/LibrariesChip.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-internal fun LibraryChip(
+fun LibraryChip(
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
     shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),

--- a/aboutlibraries-compose-m3/src/jsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.js.kt
+++ b/aboutlibraries-compose-m3/src/jsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.js.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3
+
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
+
+@androidx.compose.runtime.Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m3/src/jvmMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.jvm.kt
+++ b/aboutlibraries-compose-m3/src/jvmMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.jvm.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3
+
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
+
+@androidx.compose.runtime.Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m3/src/nativeMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.native.kt
+++ b/aboutlibraries-compose-m3/src/nativeMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.native.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3
+
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
+
+@androidx.compose.runtime.Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose-m3/src/wasmJsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.wasmJs.kt
+++ b/aboutlibraries-compose-m3/src/wasmJsMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.wasmJs.kt
@@ -1,0 +1,16 @@
+package com.mikepenz.aboutlibraries.ui.compose.m3
+
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.ui.compose.LibraryColors
+
+@androidx.compose.runtime.Composable
+actual fun LicenseDialogBody(
+    library: Library,
+    colors: LibraryColors,
+    modifier: Modifier,
+) = DefaultLicenseDialogBody(
+    library = library,
+    colors = colors,
+    modifier = modifier,
+)

--- a/aboutlibraries-compose/src/androidDebug/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffoldPreviews.kt
+++ b/aboutlibraries-compose/src/androidDebug/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffoldPreviews.kt
@@ -32,30 +32,36 @@ fun LibraryScaffoldLayoutPreview() {
         version = {
             BasicText(
                 text = "Version",
-                modifier = Modifier
-                    .background(Color.Green)
+                modifier = Modifier.background(Color.Green)
             )
         },
         author = {
             BasicText(
                 text = "Author",
-                modifier = Modifier
-                    .background(Color.Cyan)
+                modifier = Modifier.background(Color.Cyan)
             )
         },
         description = {
             BasicText(
                 text = "Description Description Description Description Description",
-                modifier = Modifier
-                    .background(Color.Magenta)
+                modifier = Modifier.background(Color.Magenta)
             )
         },
         licenses = {
             BasicText(
                 text = "Apache 2.0",
-                modifier = Modifier
-                    .background(Color.Yellow)
+                modifier = Modifier.background(Color.Yellow)
+            )
+            BasicText(
+                text = "MIT",
+                modifier = Modifier.background(Color.Yellow)
             )
         },
+        actions = {
+            BasicText(
+                text = "Action",
+                modifier = Modifier.background(Color.White)
+            )
+        }
     )
 }

--- a/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Extensions.android.kt
+++ b/aboutlibraries-compose/src/androidMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Extensions.android.kt
@@ -1,0 +1,32 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
+import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.util.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+
+/**
+ * Creates a State<Libs?> that holds the [Libs] as loaded from Android using the [Context].
+ *
+ * @see Libs
+ */
+@Composable
+fun rememberLibraries(
+    block: suspend (Context) -> Libs = { context ->
+        Libs.Builder().withContext(context).build()
+    },
+): State<Libs?> {
+    val context = LocalContext.current
+    return produceState<Libs?>(initialValue = null) {
+        value = withContext(Dispatchers.IO) {
+            block(context)
+        }
+    }
+}
+

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -80,6 +80,7 @@ object LibraryDefaults {
         descriptionTextStyle: TextStyle? = null,
         descriptionMaxLines: Int = 3,
         licensesTextStyle: TextStyle? = null,
+        fundingTextStyle: TextStyle? = null,
     ): LibraryTextStyles = DefaultLibraryTextStyles(
         defaultOverflow = defaultOverflow,
         nameTextStyle = nameTextStyle,
@@ -92,6 +93,7 @@ object LibraryDefaults {
         descriptionTextStyle = descriptionTextStyle,
         descriptionMaxLines = descriptionMaxLines,
         licensesTextStyle = licensesTextStyle,
+        fundingTextStyle = fundingTextStyle,
     )
 }
 
@@ -106,11 +108,17 @@ interface LibraryColors {
     /** Represents the content color for this library item. */
     val contentColor: Color
 
-    /** Represents the badge background color for this library item. */
+    /** Represents the license badge background color for this library item. */
     val badgeBackgroundColor: Color
 
-    /** Represents the badge content color for this library item. */
+    /** Represents the license badge content color for this library item. */
     val badgeContentColor: Color
+
+    /** Represents the funding badge background color for this library item. */
+    val fundingBadgeBackgroundColor: Color
+
+    /** Represents the funding badge content color for this library item. */
+    val fundingBadgeContentColor: Color
 
     /** Represents the text color of the dialog's confirm button  */
     val dialogConfirmButtonColor: Color
@@ -125,6 +133,8 @@ class DefaultLibraryColors(
     override val contentColor: Color,
     override val badgeBackgroundColor: Color,
     override val badgeContentColor: Color,
+    override val fundingBadgeBackgroundColor: Color,
+    override val fundingBadgeContentColor: Color,
     override val dialogConfirmButtonColor: Color,
 ) : LibraryColors
 
@@ -219,8 +229,11 @@ interface LibraryTextStyles {
     /** Represents the max lines allowed for the description text */
     val descriptionMaxLines: Int
 
-    /** Represents the text styles for the description text */
+    /** Represents the text styles for the licenses badge text */
     val licensesTextStyle: TextStyle?
+
+    /** Represents the text styles for the funding badge text */
+    val fundingTextStyle: TextStyle?
 }
 
 /**
@@ -239,4 +252,5 @@ private class DefaultLibraryTextStyles(
     override val descriptionTextStyle: TextStyle?,
     override val descriptionMaxLines: Int,
     override val licensesTextStyle: TextStyle?,
+    override val fundingTextStyle: TextStyle?,
 ) : LibraryTextStyles

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -1,10 +1,13 @@
 package com.mikepenz.aboutlibraries.ui.compose
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -100,11 +103,15 @@ object LibraryDefaults {
      * Creates a [LibraryDimensions] that represents the default dimensions used in a [Library]
      *
      * @param itemSpacing the spacing between items in the [Library]
+     * @param chipMinHeight the default min height of chip containers in the [Library]
      */
+    @Composable
     fun libraryDimensions(
         itemSpacing: Dp = 0.dp,
+        chipMinHeight: Dp = 16.dp,
     ): LibraryDimensions = DefaultLibraryDimensions(
         itemSpacing = itemSpacing,
+        chipMinHeight = chipMinHeight
     )
 
     /**
@@ -122,6 +129,7 @@ object LibraryDefaults {
      * @param descriptionMaxLines the max lines allowed for the description text
      * @param licensesTextStyle the text styles for the licenses text
      */
+    @Composable
     fun libraryTextStyles(
         defaultOverflow: TextOverflow = TextOverflow.Ellipsis,
         nameTextStyle: TextStyle? = null,
@@ -148,6 +156,16 @@ object LibraryDefaults {
         descriptionMaxLines = descriptionMaxLines,
         licensesTextStyle = licensesTextStyle,
         fundingTextStyle = fundingTextStyle,
+    )
+
+    /**
+     * Creates a [LibraryShapes] that represents the default shapes used in a [Library]
+     */
+    @Composable
+    fun libraryShapes(
+        chipShape: Shape = RoundedCornerShape(CornerSize(percent = 50)),
+    ): LibraryShapes = DefaultLibraryShapes(
+        chipShape = chipShape,
     )
 }
 
@@ -256,6 +274,9 @@ private class DefaultChipPadding(
 interface LibraryDimensions {
     /** Represents the spacing between items in the [Library] */
     val itemSpacing: Dp
+
+    /** Represents the default min height of chip containers in the [Library] */
+    val chipMinHeight: Dp
 }
 
 /**
@@ -264,6 +285,7 @@ interface LibraryDimensions {
 @Immutable
 private class DefaultLibraryDimensions(
     override val itemSpacing: Dp,
+    override val chipMinHeight: Dp,
 ) : LibraryDimensions
 
 /**
@@ -326,3 +348,21 @@ private class DefaultLibraryTextStyles(
     override val licensesTextStyle: TextStyle?,
     override val fundingTextStyle: TextStyle?,
 ) : LibraryTextStyles
+
+
+/**
+ * Represents the shape used for chips in a library.
+ */
+@Stable
+interface LibraryShapes {
+    /** The [Shape] used for chips. */
+    val chipShape: Shape
+}
+
+/**
+ * Default [LibraryShapes].
+ */
+@Immutable
+private class DefaultLibraryShapes(
+    override val chipShape: Shape,
+) : LibraryShapes

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -180,17 +180,14 @@ interface LibraryColors {
     /** Represents the content color for this library item. */
     val contentColor: Color
 
-    /** Represents the license badge background color for this library item. */
-    val badgeBackgroundColor: Color
+    /** Represents the colors used for the [Library.artifactVersion] chip. */
+    val versionChipColors: ChipColors
 
-    /** Represents the license badge content color for this library item. */
-    val badgeContentColor: Color
+    /** Represents the colors used for the [Library.licenses] chip. */
+    val licenseChipColors: ChipColors
 
-    /** Represents the funding badge background color for this library item. */
-    val fundingBadgeBackgroundColor: Color
-
-    /** Represents the funding badge content color for this library item. */
-    val fundingBadgeContentColor: Color
+    /** Represents the colors used for the [Library.funding] chip. */
+    val fundingChipColors: ChipColors
 
     /** Represents the text color of the dialog's confirm button  */
     val dialogConfirmButtonColor: Color
@@ -203,13 +200,30 @@ interface LibraryColors {
 class DefaultLibraryColors(
     override val backgroundColor: Color,
     override val contentColor: Color,
-    override val badgeBackgroundColor: Color,
-    override val badgeContentColor: Color,
-    override val fundingBadgeBackgroundColor: Color,
-    override val fundingBadgeContentColor: Color,
+    override val versionChipColors: ChipColors,
+    override val licenseChipColors: ChipColors,
+    override val fundingChipColors: ChipColors,
     override val dialogConfirmButtonColor: Color,
 ) : LibraryColors
 
+/** Represents the color values used for a chip.*/
+@Stable
+interface ChipColors {
+    /** Represents the background color of the Chip */
+    val containerColor: Color
+
+    /** Represents the color inside the Chip UI element (for the text) */
+    val contentColor: Color
+}
+
+/**
+ * Default [ChipColors].
+ */
+@Immutable
+class DefaultChipColors(
+    override val containerColor: Color,
+    override val contentColor: Color,
+) : ChipColors
 
 /**
  * Represents the padding values used in a library.

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -75,6 +75,7 @@ object LibraryDefaults {
         licensePadding: ChipPadding = chipPadding(),
         fundingPadding: ChipPadding = chipPadding(),
         verticalPadding: Dp = 2.dp,
+        licenseDialogContentPadding: Dp = 8.dp,
     ): LibraryPadding = DefaultLibraryPadding(
         contentPadding = contentPadding,
         namePadding = namePadding,
@@ -82,6 +83,7 @@ object LibraryDefaults {
         licensePadding = licensePadding,
         fundingPadding = fundingPadding,
         verticalPadding = verticalPadding,
+        licenseDialogContentPadding = licenseDialogContentPadding,
     )
 
     /**
@@ -247,6 +249,9 @@ interface LibraryPadding {
 
     /** Represents the vertical padding between the individual items in the library element */
     val verticalPadding: Dp
+
+    /** Represents the padding used for the content in the license dialog. */
+    val licenseDialogContentPadding: Dp
 }
 
 /**
@@ -260,6 +265,7 @@ private class DefaultLibraryPadding(
     override val licensePadding: ChipPadding,
     override val fundingPadding: ChipPadding,
     override val verticalPadding: Dp,
+    override val licenseDialogContentPadding: Dp,
 ) : LibraryPadding
 
 /** Represents the padding values used for a chip.*/

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -25,23 +25,75 @@ object LibraryDefaults {
      * @param badgeContentPadding the padding around the content of a badge element shown as part of a [Library]
      * @param verticalPadding the vertical padding between the individual items in the library element
      */
+    @Deprecated("Use libraryPadding() with chipPadding() arguments instead", level = DeprecationLevel.WARNING)
+    @Composable
+    fun libraryPadding(
+        contentPadding: PaddingValues, // Remove default to not conflict with new API. PaddingValues(16.dp)
+        namePadding: PaddingValues = PaddingValues(0.dp),
+        versionPadding: PaddingValues = PaddingValues(start = 8.dp),
+        badgePadding: PaddingValues = PaddingValues(top = 8.dp, end = 4.dp),
+        badgeContentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+        verticalPadding: Dp = 2.dp,
+    ): LibraryPadding = libraryPadding(
+        contentPadding = contentPadding,
+        namePadding = namePadding,
+        versionPadding = chipPadding(
+            containerPadding = versionPadding,
+            contentPadding = badgeContentPadding,
+        ),
+        licensePadding = chipPadding(
+            containerPadding = badgePadding,
+            contentPadding = badgeContentPadding,
+        ),
+        fundingPadding = chipPadding(
+            containerPadding = badgePadding,
+            contentPadding = badgeContentPadding,
+        ),
+        verticalPadding = verticalPadding,
+    )
+
+    /**
+     * Creates a [LibraryPadding] that represents the default paddings used in a [Library]
+     *
+     * @param contentPadding the padding inside the [Library] ui element
+     * @param namePadding the padding around the name shown as part of a [Library]
+     * @param versionPadding the padding in and around the version shown as part of a [Library]
+     * @param licensePadding the padding in and around the license shown as part of a [Library]
+     * @param fundingPadding the padding in and around the funding shown as part of a [Library]
+     * @param verticalPadding the vertical padding between the individual items in the library element
+     */
     @Composable
     fun libraryPadding(
         contentPadding: PaddingValues = PaddingValues(16.dp),
         namePadding: PaddingValues = PaddingValues(0.dp),
-        versionPadding: PaddingValues = PaddingValues(start = 8.dp),
-        versionBadgePadding: PaddingValues = PaddingValues(horizontal = 6.dp),
-        badgePadding: PaddingValues = PaddingValues(top = 8.dp, end = 4.dp),
-        badgeContentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+        versionPadding: ChipPadding = chipPadding(
+            containerPadding = PaddingValues(start = 8.dp),
+        ),
+        licensePadding: ChipPadding = chipPadding(),
+        fundingPadding: ChipPadding = chipPadding(),
         verticalPadding: Dp = 2.dp,
     ): LibraryPadding = DefaultLibraryPadding(
         contentPadding = contentPadding,
         namePadding = namePadding,
         versionPadding = versionPadding,
-        versionBadgePadding = versionBadgePadding,
-        badgePadding = badgePadding,
-        badgeContentPadding = badgeContentPadding,
+        licensePadding = licensePadding,
+        fundingPadding = fundingPadding,
         verticalPadding = verticalPadding,
+    )
+
+    /**
+     * Creates a ChipPadding that represents the default paddings used in a chip in a [Library].
+     *
+     * @param containerPadding the padding around the Chip UI Element
+     * @param contentPadding the padding inside the Chip UI element
+     */
+    @Composable
+    fun chipPadding(
+        containerPadding: PaddingValues = PaddingValues(top = 8.dp, end = 4.dp),
+        contentPadding: PaddingValues = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
+    ): ChipPadding = DefaultChipPadding(
+        containerPadding = containerPadding,
+        contentPadding = contentPadding,
     )
 
     /**
@@ -152,17 +204,14 @@ interface LibraryPadding {
     /** Represents the padding around the name shown as part of a [Library] */
     val namePadding: PaddingValues
 
-    /** Represents the padding around the version shown as part of a [Library] */
-    val versionPadding: PaddingValues
+    /** Represents the padding values used for the chip containing the [Library.artifactVersion] */
+    val versionPadding: ChipPadding
 
-    /** Represents the padding around the version text shown as part of a [Library] */
-    val versionBadgePadding: PaddingValues
+    /** Represents the padding values used for the chip containing the [Library.licenses] */
+    val licensePadding: ChipPadding
 
-    /** Represents the padding around a badge element shown as part of a [Library] */
-    val badgePadding: PaddingValues
-
-    /** Represents the padding around the content of a badge element shown as part of a [Library] */
-    val badgeContentPadding: PaddingValues
+    /** Represents the padding values used for the chip containing the [Library.funding] funding */
+    val fundingPadding: ChipPadding
 
     /** Represents the vertical padding between the individual items in the library element */
     val verticalPadding: Dp
@@ -175,13 +224,30 @@ interface LibraryPadding {
 private class DefaultLibraryPadding(
     override val contentPadding: PaddingValues,
     override val namePadding: PaddingValues,
-    override val versionPadding: PaddingValues,
-    override val versionBadgePadding: PaddingValues,
-    override val badgePadding: PaddingValues,
-    override val badgeContentPadding: PaddingValues,
+    override val versionPadding: ChipPadding,
+    override val licensePadding: ChipPadding,
+    override val fundingPadding: ChipPadding,
     override val verticalPadding: Dp,
 ) : LibraryPadding
 
+/** Represents the padding values used for a chip.*/
+@Stable
+interface ChipPadding {
+    /** Represents the padding around the Chip UI Element */
+    val containerPadding: PaddingValues
+
+    /** Represents the padding inside the Chip UI element */
+    val contentPadding: PaddingValues
+}
+
+/**
+ * Default [ChipPadding].
+ */
+@Immutable
+private class DefaultChipPadding(
+    override val containerPadding: PaddingValues,
+    override val contentPadding: PaddingValues,
+) : ChipPadding
 
 /**
  * Represents the padding values used in a library.

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Defaults.kt
@@ -30,13 +30,15 @@ object LibraryDefaults {
         contentPadding: PaddingValues = PaddingValues(16.dp),
         namePadding: PaddingValues = PaddingValues(0.dp),
         versionPadding: PaddingValues = PaddingValues(start = 8.dp),
+        versionBadgePadding: PaddingValues = PaddingValues(horizontal = 6.dp),
         badgePadding: PaddingValues = PaddingValues(top = 8.dp, end = 4.dp),
-        badgeContentPadding: PaddingValues = PaddingValues(0.dp),
+        badgeContentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
         verticalPadding: Dp = 2.dp,
     ): LibraryPadding = DefaultLibraryPadding(
         contentPadding = contentPadding,
         namePadding = namePadding,
         versionPadding = versionPadding,
+        versionBadgePadding = versionBadgePadding,
         badgePadding = badgePadding,
         badgeContentPadding = badgeContentPadding,
         verticalPadding = verticalPadding,
@@ -153,6 +155,9 @@ interface LibraryPadding {
     /** Represents the padding around the version shown as part of a [Library] */
     val versionPadding: PaddingValues
 
+    /** Represents the padding around the version text shown as part of a [Library] */
+    val versionBadgePadding: PaddingValues
+
     /** Represents the padding around a badge element shown as part of a [Library] */
     val badgePadding: PaddingValues
 
@@ -171,6 +176,7 @@ private class DefaultLibraryPadding(
     override val contentPadding: PaddingValues,
     override val namePadding: PaddingValues,
     override val versionPadding: PaddingValues,
+    override val versionBadgePadding: PaddingValues,
     override val badgePadding: PaddingValues,
     override val badgeContentPadding: PaddingValues,
     override val verticalPadding: Dp,

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Extensions.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/Extensions.kt
@@ -36,3 +36,20 @@ fun rememberLibraries(
         }
     }
 }
+
+
+/**
+ * Creates a State<Libs?> that holds the [Libs] as loaded by the [libraries].
+ *
+ * @see Libs
+ */
+@Composable
+fun rememberLibraries(
+    libraries: String,
+): State<Libs?> {
+    return produceState<Libs?>(initialValue = null) {
+        value = withContext(Dispatchers.Default) {
+            Libs.Builder().withJson(libraries).build()
+        }
+    }
+}

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/LibrariesScaffold.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/LibrariesScaffold.kt
@@ -1,0 +1,137 @@
+package com.mikepenz.aboutlibraries.ui.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.FlowRowScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
+import com.mikepenz.aboutlibraries.entity.Funding
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.ui.compose.layout.LibraryScaffoldLayout
+import com.mikepenz.aboutlibraries.ui.compose.util.author
+import kotlinx.collections.immutable.ImmutableList
+
+/**
+ * A composable function that displays a scaffolded list of libraries with customizable content.
+ *
+ * @param libraries The list of libraries to display.
+ * @param modifier Modifier to be applied to the LazyColumn.
+ * @param libraryModifier Modifier to be applied to each library item.
+ * @param lazyListState The state object to control or observe the LazyColumn's scroll state.
+ * @param contentPadding Padding values to be applied around the content.
+ * @param padding Padding configuration for each library item.
+ * @param dimensions Dimensions configuration for spacing and layout.
+ * @param name A composable lambda to display the library name.
+ * @param version A composable lambda to display the library version (optional).
+ * @param author A composable lambda to display the library author(s) (optional).
+ * @param description A composable lambda to display the library description (optional).
+ * @param license A composable lambda to display the library licenses (optional).
+ * @param funding A composable lambda to display the library funding information (optional).
+ * @param actions A composable lambda to display additional actions for each library (optional).
+ * @param header A lambda to define the header content of the list (optional).
+ * @param divider A composable lambda to define a divider between library items (optional).
+ * @param footer A lambda to define the footer content of the list (optional).
+ * @param onLibraryClick A callback invoked when a library item is clicked. Returns `true` if the click is handled.
+ */
+@Composable
+fun LibrariesScaffold(
+    libraries: ImmutableList<Library>,
+    modifier: Modifier = Modifier,
+    libraryModifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    padding: LibraryPadding = LibraryDefaults.libraryPadding(),
+    dimensions: LibraryDimensions = LibraryDefaults.libraryDimensions(),
+    name: @Composable BoxScope.(name: String) -> Unit = {},
+    version: (@Composable BoxScope.(version: String) -> Unit)? = null,
+    author: (@Composable BoxScope.(authors: String) -> Unit)? = null,
+    description: (@Composable BoxScope.(description: String) -> Unit)? = null,
+    license: (@Composable FlowRowScope.(license: License) -> Unit)? = null,
+    funding: (@Composable FlowRowScope.(funding: Funding) -> Unit)? = null,
+    actions: (@Composable FlowRowScope.(library: Library) -> Unit)? = null,
+    header: (LazyListScope.() -> Unit)? = null,
+    divider: (@Composable LazyItemScope.() -> Unit)? = null,
+    footer: (LazyListScope.() -> Unit)? = null,
+    onLibraryClick: ((Library) -> Boolean)? = { false },
+) {
+    val uriHandler = LocalUriHandler.current
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(dimensions.itemSpacing),
+        state = lazyListState,
+        contentPadding = contentPadding
+    ) {
+        header?.invoke(this)
+        itemsIndexed(libraries) { index, library ->
+            LibraryScaffoldLayout(
+                modifier = libraryModifier.clickable {
+                    val license = library.licenses.firstOrNull()
+                    val handled = onLibraryClick?.invoke(library) ?: false
+
+                    if (!handled && !license?.url.isNullOrBlank()) {
+                        license.url?.also {
+                            try {
+                                uriHandler.openUri(it)
+                            } catch (t: Throwable) {
+                                println("Failed to open url: $it // ${t.message}")
+                            }
+                        }
+                    }
+                },
+                libraryPadding = padding,
+                name = { name(library.name) },
+                version = {
+                    val artifactVersion = library.artifactVersion
+                    if (version != null && artifactVersion != null) {
+                        version(artifactVersion)
+                    }
+                },
+                author = {
+                    val authors = library.author
+                    if (author != null && authors.isNotBlank()) {
+                        author(authors)
+                    }
+                },
+                description = {
+                    val desc = library.description
+                    if (description != null && !desc.isNullOrBlank()) {
+                        description(desc)
+                    }
+                },
+                licenses = {
+                    if (license != null && library.licenses.isNotEmpty()) {
+                        library.licenses.forEach {
+                            license(it)
+                        }
+                    }
+                },
+                actions = {
+                    if (funding != null && library.funding.isNotEmpty()) {
+                        library.funding.forEach {
+                            funding(it)
+                        }
+                    }
+                    if (actions != null) {
+                        actions(library)
+                    }
+                }
+            )
+
+            if (divider != null && index < libraries.lastIndex) {
+                divider.invoke(this)
+            }
+        }
+        footer?.invoke(this)
+    }
+}

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffold.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffold.kt
@@ -35,6 +35,7 @@ fun LibraryScaffoldLayout(
     author: @Composable BoxScope.() -> Unit,
     description: @Composable BoxScope.() -> Unit,
     licenses: @Composable FlowRowScope.() -> Unit,
+    actions: @Composable FlowRowScope.() -> Unit,
     modifier: Modifier = Modifier,
     libraryPadding: LibraryPadding = LibraryDefaults.libraryPadding(),
 ) {
@@ -45,7 +46,10 @@ fun LibraryScaffoldLayout(
             Box(Modifier.layoutId(LibraryLayoutContent.Version).padding(libraryPadding.versionPadding), content = version)
             Box(Modifier.layoutId(LibraryLayoutContent.Author), content = author)
             Box(Modifier.layoutId(LibraryLayoutContent.Description), content = description)
-            FlowRow(Modifier.layoutId(LibraryLayoutContent.Licenses), content = licenses)
+            FlowRow(Modifier.layoutId(LibraryLayoutContent.Actions), content = {
+                licenses()
+                actions()
+            })
         },
     ) { measurables, constraints ->
         // don't allow version to take more than 30%
@@ -65,7 +69,7 @@ fun LibraryScaffoldLayout(
         val descriptionPlaceable = measurables.fastFirst { it.layoutId == LibraryLayoutContent.Description }.measure(constraints.copy(minWidth = 0))
 
         val descriptionGuideline = authorGuideline + descriptionPlaceable.height + libraryPadding.verticalPadding.toPx().toInt()
-        val licensesPlaceable = measurables.fastFirst { it.layoutId == LibraryLayoutContent.Licenses }.measure(constraints.copy(minWidth = 0))
+        val licensesPlaceable = measurables.fastFirst { it.layoutId == LibraryLayoutContent.Actions }.measure(constraints.copy(minWidth = 0))
 
         val layoutHeight = descriptionGuideline + licensesPlaceable.height
 
@@ -80,5 +84,5 @@ fun LibraryScaffoldLayout(
 }
 
 private enum class LibraryLayoutContent {
-    Name, Version, Author, Description, Licenses
+    Name, Version, Author, Description, Actions
 }

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffold.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/layout/LibraryScaffold.kt
@@ -43,7 +43,7 @@ fun LibraryScaffoldLayout(
         modifier = modifier.padding(libraryPadding.contentPadding),
         content = {
             Box(Modifier.layoutId(LibraryLayoutContent.Name).padding(libraryPadding.namePadding).fillMaxWidth(), content = name)
-            Box(Modifier.layoutId(LibraryLayoutContent.Version).padding(libraryPadding.versionPadding), content = version)
+            Box(Modifier.layoutId(LibraryLayoutContent.Version), content = version)
             Box(Modifier.layoutId(LibraryLayoutContent.Author), content = author)
             Box(Modifier.layoutId(LibraryLayoutContent.Description), content = description)
             FlowRow(Modifier.layoutId(LibraryLayoutContent.Actions), content = {

--- a/app-desktop/src/jvmMain/kotlin/m2/main.kt
+++ b/app-desktop/src/jvmMain/kotlin/m2/main.kt
@@ -18,13 +18,14 @@ fun main() = application {
     Window(title = "AboutLibraries Sample", onCloseRequest = ::exitApplication) {
         SampleTheme {
             Scaffold(
-                topBar = { TopAppBar(title = { Text("AboutLibraries Compose Desktop Sample") }) }) {
+                topBar = { TopAppBar(title = { Text("AboutLibraries Compose Desktop Sample", maxLines = 1) }) }) {
                 val libraries by rememberLibraries {
                     Res.readBytes("files/aboutlibraries.json").decodeToString()
                 }
                 LibrariesContainer(
                     libraries = libraries,
                     modifier = Modifier.fillMaxSize(),
+                    showFundingBadges = true,
                     // divider = { Divider(modifier = Modifier.fillMaxWidth()) }
                 )
             }

--- a/app-desktop/src/jvmMain/kotlin/m3/main.kt
+++ b/app-desktop/src/jvmMain/kotlin/m3/main.kt
@@ -25,17 +25,18 @@ fun main() = application {
     Window(title = "AboutLibraries M3 Sample", onCloseRequest = ::exitApplication) {
         AppTheme {
             Scaffold(
-                topBar = { TopAppBar(title = { Text("AboutLibraries Compose M3 Desktop Sample") }) }) {
+                topBar = { TopAppBar(title = { Text("AboutLibraries Compose M3 Desktop Sample", maxLines = 1) }) }) {
                 val libraries by rememberLibraries {
                     Res.readBytes("files/aboutlibraries.json").decodeToString()
                 }
                 LibrariesContainer(
                     libraries = libraries,
                     modifier = Modifier.fillMaxSize().padding(it),
+                    showFundingBadges = true,
                     header = {
                         item {
                             Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                                Text("Hello Header")
+                                Text("Hello Header", maxLines = 1)
                             }
                         }
                     },
@@ -43,7 +44,7 @@ fun main() = application {
                     footer = {
                         item {
                             Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                                Text("Hello Footer")
+                                Text("Hello Footer", maxLines = 1)
                             }
                         }
                     }


### PR DESCRIPTION
- rework m2 / m3 Library base composable to make it more flexible, and allow for more flexible custom theming for integrations
- offer ability to fully customize each section of the library card
- use chip instead of badge for version, license, and funding
- use chip instead of badge for version, license, and funding for M3 as well
- introduce chip padding data type to simplify configuration for the different chip containers
- add new API to define the shape for the chips, giving greater flexibility
- expand shared libraries API to offer full customisation of each composable
- add better API to configure chip colors
- rework libraries so we can remove all the duplicated logic, and instruct people to use the `remember*` APIs to load the `libs` instead
- also make android dialog implementation an expect, so we don't need different Android APIs either
- rework dialog to have better sizing and spacings


TODO:
- api validation fails due to strange compiler error
- local publishing fails due to klib warning 