### PR TITLE
Add the name nullability to organization. The name is absent in some …

### DIFF
--- a/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
+++ b/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
@@ -34,7 +34,7 @@ actual fun parseData(json: String): Result {
                 Developer(optString("name"), optString("organisationUrl"))
             } ?: emptyList()
             val organization = optJSONObject("organization")?.let {
-                Organization(it.optString("name"), it.optString("url"))
+                Organization(it.optString("name") ?: "", it.optString("url"))
             }
             val scm = optJSONObject("scm")?.let {
                 Scm(

--- a/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
+++ b/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidParser.kt
@@ -34,7 +34,7 @@ actual fun parseData(json: String): Result {
                 Developer(optString("name"), optString("organisationUrl"))
             } ?: emptyList()
             val organization = optJSONObject("organization")?.let {
-                Organization(it.getString("name"), it.optString("url"))
+                Organization(it.optString("name"), it.optString("url"))
             }
             val scm = optJSONObject("scm")?.let {
                 Scm(

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
@@ -13,6 +13,6 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class Organization(
-    @SerialName("name") val name: String?,
-    @SerialName("url") val url: String?
+    @SerialName("name") val name: String,
+    @SerialName("url") val url: String?,
 )

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/entity/Organization.kt
@@ -13,6 +13,6 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class Organization(
-    @SerialName("name") val name: String,
+    @SerialName("name") val name: String?,
     @SerialName("url") val url: String?
 )

--- a/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
+++ b/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
@@ -34,7 +34,7 @@ actual fun parseData(json: String): Result {
                 Developer(optString("name"), optString("organisationUrl"))
             } ?: emptyList()
             val organization = optJSONObject("organization")?.let {
-                Organization(it.optString("name"), it.optString("url"))
+                Organization(it.optString("name") ?: "", it.optString("url"))
             }
             val scm = optJSONObject("scm")?.let {
                 Scm(

--- a/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
+++ b/aboutlibraries-core/src/multiplatformMain/kotlin/com/mikepenz/aboutlibraries/util/MultiplatformParser.kt
@@ -34,7 +34,7 @@ actual fun parseData(json: String): Result {
                 Developer(optString("name"), optString("organisationUrl"))
             } ?: emptyList()
             val organization = optJSONObject("organization")?.let {
-                Organization(it.getString("name"), it.optString("url"))
+                Organization(it.optString("name"), it.optString("url"))
             }
             val scm = optJSONObject("scm")?.let {
                 Scm(

--- a/aboutlibraries/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/SerializeableContainer.kt
+++ b/aboutlibraries/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/SerializeableContainer.kt
@@ -1,7 +1,12 @@
 package com.mikepenz.aboutlibraries.util
 
 import com.mikepenz.aboutlibraries.Libs
-import com.mikepenz.aboutlibraries.entity.*
+import com.mikepenz.aboutlibraries.entity.Developer
+import com.mikepenz.aboutlibraries.entity.Funding
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.entity.Organization
+import com.mikepenz.aboutlibraries.entity.Scm
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import java.io.Serializable
@@ -38,7 +43,7 @@ internal fun SerializableLibs.toLibs() = Libs(
             lib.description,
             lib.website,
             lib.developers.map { Developer(it.name, it.organisationUrl) }.toImmutableList(),
-            lib.organization?.let { Organization(it.name, it.url) },
+            lib.organization?.let { Organization(it.name ?: "", it.url) },
             lib.scm?.let { Scm(it.connection, it.developerConnection, it.url) },
             lib.licenses.map {
                 License(it.name, it.url, it.year, it.spdxId, it.licenseContent, it.hash)

--- a/aboutlibraries/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/SerializeableContainer.kt
+++ b/aboutlibraries/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/SerializeableContainer.kt
@@ -91,7 +91,7 @@ internal data class SerializableLicense(
 ) : Serializable
 
 internal data class SerializableOrganization(
-    val name: String,
+    val name: String?,
     val url: String?,
 ) : Serializable
 


### PR DESCRIPTION
…libraries. For instance org.opencv:opencv.

The next PR fixes the crash that occurs when parsing an empty organization in the aboutlibraries.json. 
Another approach is to fix the Organization entity during JSON generation in the DependencyCollector in the plugin. However, it needs more ground knowledge of the project data structure. 

The empty organization example.
```
{
      "uniqueId": "org.opencv:opencv",
      "funding": [],
      "developers": [
        {
          "name": "OpenCV Team"
        }
      ],
      "artifactVersion": "4.11.0",
      "description": "Open Source Computer Vision Library",
      "scm": {
        "connection": "scm:git:https://github.com/opencv/opencv.git",
        "url": "https://github.com/opencv/opencv"
      },
      "name": "OpenCV",
      "website": "https://opencv.org/",
      "licenses": [
        "Apache-2.0"
      ],
      "organization": {}
    }
```