### PR TITLE
Upgrade to Kotlin 2.2 | Compose 1.8.3 / 1.8.2 | Serialization 1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,11 +6,14 @@
 - **Breaking Change**: The `Gradle Plugin` was split into 2. The main plugin that is registering all the manual tasks, and an Android specific one automatically registering the Android auto
   generation task.
   - For most projects the manual tasks are recommended. Only if you require or want to use the generation as part of the android build, use the `.android` plugin.
+  - The main plugin (`com.mikepenz.aboutlibraries.plugin`) provides tasks like `exportLibraryDefinitions` that need to be manually executed
+  - The Android plugin (`com.mikepenz.aboutlibraries.plugin.android`) automatically hooks into the Android build process
 
 ```kotlin
 // To use the Android auto registering plugin - add the following to your module:
 id("com.mikepenz.aboutlibraries.plugin.android")
 ```
+- **Breaking Change**: The `AndroidConfig` class and its `registerAndroidTasks` property were removed, replaced by the Android-specific plugin
 - **Breaking Change**: Reworked the `LibraryColors` interface to be more descriptive and more flexible
   - Renamed `backgroundColor` to `libraryBackgroundColor`
   - Renamed `contentColor` to `libraryContentColor`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This library collects dependency details, including licenses at compile time, an
 
 ## Latest releases 🛠
 
-- Split Gradle Plugin | [v13.0.0](https://github.com/mikepenz/AboutLibraries/tree/12.2.4)
+- Split Gradle Plugin | [v13.0.0](https://github.com/mikepenz/AboutLibraries/tree/13.0.0)
 - Compose 1.8.x | Refined Compose UI Design | [v12.2.4](https://github.com/mikepenz/AboutLibraries/tree/12.2.4)
 - Compose UI updates | Gradle Plugin refresh | [v12.0.1](https://github.com/mikepenz/AboutLibraries/tree/12.0.1)
 
@@ -53,12 +53,21 @@ Note: It will not automatically generate the meta-data. For Android see the andr
 > The Gradle plugin is hosted via the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.mikepenz.aboutlibraries.plugin).
 > Using the `plugins` DSL is the recommended approach.
 
-> [!NOTE]  
-> v13.x.y or newer moves the Android specific task registration into its own plugin.
-> Please see the migration guide for more details.
+> [!IMPORTANT]  
+> In v13.x.y, the Gradle Plugin was split into two separate plugins:
+>
+> 1. **Main Plugin** (`com.mikepenz.aboutlibraries.plugin`): Provides manual tasks for generating library definitions
+> 2. **Android Plugin** (`com.mikepenz.aboutlibraries.plugin.android`): Automatically hooks into the Android build process
+>
+> For most projects, the main plugin is recommended. Only use the Android plugin if you specifically need the library definitions to be generated as part of the Android build
+> process.
+>
+> See the [migration guide](MIGRATION.md) for more details.
 
 <details open><summary><b>Using the plugins DSL (Recommended)</b></summary>
 <p>
+
+## Default Gradle Plugin - Multiplatform
 
 ```kts
 // Root build.gradle.kts
@@ -67,6 +76,23 @@ id("com.mikepenz.aboutlibraries.plugin") version "${latestAboutLibsRelease}" app
 // App build.gradle.kts
 id("com.mikepenz.aboutlibraries.plugin")
 ```
+
+## Gradle Plugin - Android
+
+To improve configuration cache compatibility and reduce unintended behavior, the auto registering as part of the Android build was moved into its own plugin in v13.x.y.
+
+```kotlin
+// App build.gradle.kts
+id("com.mikepenz.aboutlibraries.plugin.android")
+```
+
+When using the `.android` plugin variant:
+
+- The library definitions are automatically generated as part of the Android build process
+- The `registerAndroidTasks` configuration no longer exists, as it now happens by default
+- The generated file is automatically included in your Android resources
+- No manual execution of tasks is required
+
 
 </p>
 </details>
@@ -98,16 +124,6 @@ apply plugin: 'com.mikepenz.aboutlibraries.plugin'
 
 <details><summary><b>Gradle Plugin Configuration Options</b></summary>
 <p>
-
-## Gradle Plugin - Android
-
-To improve configuration cache compatibility and reduce unintended behavior, the auto registering as part of the Android build was moved into its own plugin. 
-When using the `.android` plugin variant, the `registerAndroidTasks` configuration does no longer exist, as it now happens by default. If you do not need the meta data to be generated as part of the android build - the default plugin is recommended.
-
-```kotlin
-// App build.gradle.kts
-id("com.mikepenz.aboutlibraries.plugin.android")
-```
 
 ## Gradle Plugin Configuration
 
@@ -171,8 +187,8 @@ aboutLibraries {
 
     license {
         // Define the strict mode, will fail if the project uses licenses not allowed
-        // - This will only automatically fail for Android projects which have `registerAndroidTasks` enabled
-        // For non Android projects, execute `exportLibraryDefinitions`
+        // - This will only automatically fail for Android projects using the Android-specific plugin (com.mikepenz.aboutlibraries.plugin.android)
+        // For other projects, execute `exportLibraryDefinitions` manually
         strictMode = com.mikepenz.aboutlibraries.plugin.StrictMode.FAIL
 
         // Allowed set of licenses, this project will be able to use without build failure

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This library collects dependency details, including licenses at compile time, an
 
 ## Latest releases 🛠
 
+- Split Gradle Plugin | [v13.0.0](https://github.com/mikepenz/AboutLibraries/tree/12.2.4)
 - Compose 1.8.x | Refined Compose UI Design | [v12.2.4](https://github.com/mikepenz/AboutLibraries/tree/12.2.4)
 - Compose UI updates | Gradle Plugin refresh | [v12.0.1](https://github.com/mikepenz/AboutLibraries/tree/12.0.1)
 

--- a/aboutlibraries-core/api/android/aboutlibraries-core.api
+++ b/aboutlibraries-core/api/android/aboutlibraries-core.api
@@ -12,7 +12,7 @@ public final class com/mikepenz/aboutlibraries/Libs {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/Libs$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/Libs;
@@ -20,6 +20,7 @@ public synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/se
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/Libs;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/Libs$Builder {
@@ -46,7 +47,7 @@ public final class com/mikepenz/aboutlibraries/entity/Developer {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Developer$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Developer;
@@ -54,6 +55,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Developer;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Developer$Companion {
@@ -74,7 +76,7 @@ public final class com/mikepenz/aboutlibraries/entity/Funding {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Funding$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Funding;
@@ -82,6 +84,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Funding;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Funding$Companion {
@@ -123,7 +126,7 @@ public final class com/mikepenz/aboutlibraries/entity/Library {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Library$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Library;
@@ -131,6 +134,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Library;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Library$Companion {
@@ -160,7 +164,7 @@ public final class com/mikepenz/aboutlibraries/entity/License {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/License$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/License;
@@ -168,6 +172,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/License;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/License$Companion {
@@ -188,7 +193,7 @@ public final class com/mikepenz/aboutlibraries/entity/Organization {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Organization$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Organization;
@@ -196,6 +201,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializ
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Organization;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Organization$Companion {
@@ -218,7 +224,7 @@ public final class com/mikepenz/aboutlibraries/entity/Scm {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Scm$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Scm;
@@ -226,6 +232,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotl
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Scm;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Scm$Companion {

--- a/aboutlibraries-core/api/jvm/aboutlibraries-core.api
+++ b/aboutlibraries-core/api/jvm/aboutlibraries-core.api
@@ -12,7 +12,7 @@ public final class com/mikepenz/aboutlibraries/Libs {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/Libs$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/Libs;
@@ -20,6 +20,7 @@ public synthetic class com/mikepenz/aboutlibraries/Libs$$serializer : kotlinx/se
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/Libs;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/Libs$Builder {
@@ -46,7 +47,7 @@ public final class com/mikepenz/aboutlibraries/entity/Developer {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Developer$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Developer;
@@ -54,6 +55,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Developer$$serializer 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Developer;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Developer$Companion {
@@ -74,7 +76,7 @@ public final class com/mikepenz/aboutlibraries/entity/Funding {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Funding$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Funding;
@@ -82,6 +84,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Funding$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Funding;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Funding$Companion {
@@ -123,7 +126,7 @@ public final class com/mikepenz/aboutlibraries/entity/Library {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Library$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Library;
@@ -131,6 +134,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Library$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Library;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Library$Companion {
@@ -160,7 +164,7 @@ public final class com/mikepenz/aboutlibraries/entity/License {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/License$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/License;
@@ -168,6 +172,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/License$$serializer : 
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/License;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/License$Companion {
@@ -188,7 +193,7 @@ public final class com/mikepenz/aboutlibraries/entity/Organization {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Organization$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Organization;
@@ -196,6 +201,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Organization$$serializ
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Organization;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Organization$Companion {
@@ -218,7 +224,7 @@ public final class com/mikepenz/aboutlibraries/entity/Scm {
 	public fun toString ()Ljava/lang/String;
 }
 
-public synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/mikepenz/aboutlibraries/entity/Scm$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/mikepenz/aboutlibraries/entity/Scm;
@@ -226,6 +232,7 @@ public synthetic class com/mikepenz/aboutlibraries/entity/Scm$$serializer : kotl
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/mikepenz/aboutlibraries/entity/Scm;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/mikepenz/aboutlibraries/entity/Scm$Companion {

--- a/aboutlibraries/api/aboutlibraries.api
+++ b/aboutlibraries/api/aboutlibraries.api
@@ -320,5 +320,7 @@ public final class com/mikepenz/aboutlibraries/viewmodel/LibsViewModel : android
 public final class com/mikepenz/aboutlibraries/viewmodel/LibsViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public fun <init> (Landroid/content/Context;Lcom/mikepenz/aboutlibraries/LibsBuilder;Lcom/mikepenz/aboutlibraries/Libs$Builder;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
+	public fun create (Ljava/lang/Class;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
+	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,3 +47,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # convention plugin
 com.mikepenz.binary-compatibility-validator.enabled=true
 com.mikepenz.version-catalog-update.enabled=true
+com.mikepenz.compatPatrouille.enabled=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,3 +48,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 com.mikepenz.binary-compatibility-validator.enabled=true
 com.mikepenz.version-catalog-update.enabled=true
 com.mikepenz.compatPatrouille.enabled=false
+com.mikepenz.kotlin.version=2.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 # kotlin
-kotlinxSerialization = "1.8.1"
+kotlinxSerialization = "1.9.0"
 # androidx
 activity = "1.10.1"
 cardview = "1.0.0"
 constraintLayout = "2.2.1"
 core = "1.16.0"
 lifecycle = { require = "2.8.7" }
-navigation = "2.8.9"
+navigation = "2.9.0"
 recyclerView = "1.4.0"
 # google
 material = "1.12.0"
@@ -16,7 +16,7 @@ fastAdapter = "5.7.0"
 iconics = "5.4.0"
 itemAnimators = "1.1.0"
 ivy = "2.5.3"
-modelBuilder = "3.9.9"
+modelBuilder = "3.9.10"
 materialDrawer = "9.0.2"
 okhttp = "4.12.0"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.3.9")
+            from("com.mikepenz:version-catalog:0.5.1")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.5.1")
+            from("com.mikepenz:version-catalog:0.6.0")
         }
     }
 }


### PR DESCRIPTION
- Kotlin 2.2.0 
- Compose 1.8.3 / Compose Multiplatform 1.8.2
- Serialization 1.9.0
- upgrade to a newer convention plugin version