### PR TITLE
Upgrade to Compose 1.9.0 | Multiplatform 1.9.0-beta03 | Compile&Target 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ kotlinxSerialization = "1.9.0"
 activity = "1.10.1"
 cardview = "1.0.0"
 constraintLayout = "2.2.1"
-core = "1.16.0"
+core = "1.17.0"
 lifecycle = { require = "2.8.7" }
-navigation = "2.9.1"
+navigation = "2.9.3"
 recyclerView = "1.4.0"
 # google
 material = "1.12.0"
@@ -16,9 +16,9 @@ fastAdapter = "5.7.0"
 iconics = "5.4.0"
 itemAnimators = "1.1.0"
 ivy = "2.5.3"
-modelBuilder = "3.9.10"
+modelBuilder = "3.9.11"
 materialDrawer = "9.0.2"
-okhttp = "5.0.0"
+okhttp = "5.1.0"
 
 [plugins]
 navSafeArgs = { id = "androidx.navigation.safeargs", version.ref = "navigation" }

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             from(files("../gradle/libs.versions.toml"))
         }
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.3.9")
+            from("com.mikepenz:version-catalog:0.5.0")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.6.0")
+            from("com.mikepenz:version-catalog:0.7.0")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.7.0")
+            from("com.mikepenz:version-catalog:0.8.0")
         }
     }
 }


### PR DESCRIPTION
- upgrade to version-catalog 0.5.0 
  - updates to compose 1.9.0
  - updates to compose-mp 1.9.0-beta03
Update dependencies: core to 1.17.0, navigation to 2.9.3, modelBuilder to 3.9.11, and okhttp to 5.1.0
- raise to target and compile SDK 36