### PR TITLE
Fix incorrect keep.xml syntax in withContext() documentation

### DIFF
--- a/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidExtensions.kt
+++ b/aboutlibraries-core/src/androidMain/kotlin/com/mikepenz/aboutlibraries/util/AndroidExtensions.kt
@@ -16,7 +16,7 @@ fun Libs.Builder.withJson(byteArray: ByteArray): Libs.Builder {
 }
 
 /**
- * Auto discover the generated library definition data by the default name and location
+ * Auto-discover the generated library definition data by the default name and location
  * `res/raw/aboutlibraries.json`
  *
  * Please remember to disable resource shrinking when using this API.
@@ -25,7 +25,7 @@ fun Libs.Builder.withJson(byteArray: ByteArray): Libs.Builder {
  * ```
  * <?xml version="1.0" encoding="utf-8"?>
  * <resources xmlns:tools="http://schemas.android.com/tools"
- *     tools:keep="@raw/aboutlibraries.json" />
+ *     tools:keep="@raw/aboutlibraries" />
  * ```
  *
  * @param ctx context used to retrieve the resource


### PR DESCRIPTION
The `keep.xml` example in the `withContext()` documentation mistakenly adds a file extension (.json) to the resource reference. As a result, R8’s optimized resource shrinking may not properly maintain the `aboutlibraries.json` file, which can lead to crashes when calling `Libs.Builder().withContext(context).build()`.