### PR TITLE
Remove legacy Android task support in Gradle Plugin, improve support for new variant API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Build Release App
         if: startsWith(github.ref, 'refs/tags/')
-        run: ./gradlew sample:android:assembleStaging sample:android:assembleRelease sample:android:bundleRelease -P"com.mikepenz.android.signing.enabled"="true" -P"com.mikepenz.android.signing.storeFile"="opensource.jks" -P"com.mikepenz.android.signing.storePassword"="${{ secrets.STORE_PASSWORD }}" -P"com.mikepenz.android.signing.keyAlias"="${{ secrets.KEY_ALIAS }}" -P"com.mikepenz.android.signing.keyPassword"="${{ secrets.KEY_PASSWORD }}"
+        run: ./gradlew sample:android:assembleRelease sample:android:bundleRelease -P"com.mikepenz.android.signing.enabled"="true" -P"com.mikepenz.android.signing.storeFile"="opensource.jks" -P"com.mikepenz.android.signing.storePassword"="${{ secrets.STORE_PASSWORD }}" -P"com.mikepenz.android.signing.keyAlias"="${{ secrets.KEY_ALIAS }}" -P"com.mikepenz.android.signing.keyPassword"="${{ secrets.KEY_PASSWORD }}"
 
       - name: Collect artifacts
         run: |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,9 @@
 
 - **Breaking Change**: The `core` plugin no longer depends on the kotlinx.immutable collections library.
     - Collections are marked as stable via the stability config file instead: https://github.com/mikepenz/AboutLibraries/pull/1267
-  
+- **Breaking Change**: The already deprecated `generateLibraryDefinitions*` tasks are now removed
+- **Breaking Change**: The plugin will now only work for projects that use AGP 7 or newer, with the new variants API via `AndroidComponentsExtension` available
+
 #### v13.2.0
 
 - **Breaking Change**: Some underlying APIs start to require API 23 instead of 21.

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
@@ -14,6 +14,13 @@ class AboutLibrariesPluginAndroid : Plugin<Project> {
             return
         }
 
+        try {
+            Class.forName("com.android.build.api.variant.AndroidComponentsExtension")
+        } catch (t: Throwable) {
+            project.logger.error("Android Gradle Plugin 7.0.0 or greater is required to apply this plugin.")
+            return
+        }
+
         // create the extension for the about libraries plugin
         val extension = project.extensions.findByType(AboutLibrariesExtension::class.java) ?: project.extensions.create("aboutLibraries", AboutLibrariesExtension::class.java)
         extension.applyConvention()

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
@@ -1,6 +1,5 @@
 package com.mikepenz.aboutlibraries.plugin
 
-import com.mikepenz.aboutlibraries.plugin.util.configure
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.util.GradleVersion
@@ -20,47 +19,7 @@ class AboutLibrariesPluginAndroid : Plugin<Project> {
         extension.applyConvention()
 
         LOGGER.debug("Enabled Android task registration")
-        configureAndroidTasks(project, extension, ::configureAndroidResourceTasks)
-    }
-
-    private fun configureAndroidResourceTasks(project: Project, extension: AboutLibrariesExtension, @Suppress("DEPRECATION") variant: com.android.build.gradle.api.BaseVariant) {
-        val variantName = variant.name.replaceFirstChar { it.uppercase() }
-
-        val resultsResDirectory = project.layout.buildDirectory.dir("generated/aboutLibraries/${variant.name}/res/")
-        val resultsDirectory = resultsResDirectory.map { it.dir("raw/") }
-
-        // task to write the general definitions information
-        val task = project.tasks.configure("prepareLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
-            it.group = ""
-            it.variant.set(variant.name)
-            it.configureOutputFile(resultsDirectory.map { dir ->
-                @Suppress("DEPRECATION")
-                dir.file(extension.export.outputFileName.get())
-            })
-            it.configure()
-        }
-
-        // This is necessary for backwards compatibility with versions of gradle that do not support this new API.
-        try {
-            variant.registerGeneratedResFolders(project.files(resultsResDirectory).builtBy(task))
-            try {
-                variant.mergeResourcesProvider.configure { it.dependsOn(task) }
-            } catch (t: Throwable) {
-                AboutLibrariesPlugin.LOGGER.error(
-                    "Couldn't register mergeResourcesProvider task dependency. This is a bug in AGP. Please report it to the Android team. ${t.message}",
-                    t
-                )
-                @Suppress("DEPRECATION") variant.mergeResources.dependsOn(task)
-            }
-        } catch (t: Throwable) {
-            AboutLibrariesPlugin.LOGGER.warn(
-                "Using deprecated API to register task, `registerGeneratedResFolders` is not supported by the environment. Upgrade your AGP version., ${t.message}",
-                t
-            )
-            @Suppress("DEPRECATION")
-            // noinspection EagerGradleConfiguration
-            variant.registerResGeneratingTask(task.get(), resultsResDirectory.get().asFile)
-        }
+        configureAndroidTasks(project, extension)
     }
 
     companion object {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -1,96 +1,30 @@
 package com.mikepenz.aboutlibraries.plugin
 
 import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.LibraryExtension
 import com.mikepenz.aboutlibraries.plugin.util.configure
 import org.gradle.api.Project
 
 internal fun configureAndroidTasks(
     project: Project,
     extension: AboutLibrariesExtension,
-    block: (Project, AboutLibrariesExtension, @Suppress("DEPRECATION") com.android.build.gradle.api.BaseVariant) -> Unit = ::configureAndroidTasks,
-    blockNew: (Project, AboutLibrariesExtension, com.android.build.api.variant.Variant) -> Unit = ::configureAndroidTasks,
+    block: (Project, AboutLibrariesExtension, com.android.build.api.variant.Variant) -> Unit = ::configureAndroidTasks,
 ) {
     project.pluginManager.withPlugin("com.android.application") {
         AboutLibrariesPlugin.LOGGER.debug("Registering Android task for Application")
 
-        val newApp = project.extensions.findByType(AndroidComponentsExtension::class.java)
-        if (newApp != null) {
-            project.extensions.configure(AndroidComponentsExtension::class.java) {
-                it.onVariants { variant ->
-                    blockNew(project, extension, variant)
-                }
-            }
-        } else {
-            val app = project.extensions.findByType(AppExtension::class.java)
-            if (app != null) {
-                app.applicationVariants.configureEach { variant -> block(project, extension, variant) }
-            } else {
-                AboutLibrariesPlugin.LOGGER.warn("No Android AppExtension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
+        project.extensions.configure(AndroidComponentsExtension::class.java) {
+            it.onVariants { variant ->
+                block(project, extension, variant)
             }
         }
     }
     project.pluginManager.withPlugin("com.android.library") {
         AboutLibrariesPlugin.LOGGER.debug("Registering Android task for Library")
-
-        val newLib = project.extensions.findByType(AndroidComponentsExtension::class.java)
-        if (newLib != null) {
-            project.extensions.configure(AndroidComponentsExtension::class.java) {
-                it.onVariants { variant ->
-                    blockNew(project, extension, variant)
-                }
-            }
-        } else {
-            val lib = project.extensions.findByType(LibraryExtension::class.java)
-            if (lib != null) {
-                lib.libraryVariants.configureEach { variant -> block(project, extension, variant) }
-            } else {
-                AboutLibrariesPlugin.LOGGER.warn("No Android LibraryExtension found. Skipping Android tasks registration. Please ensure your Android Gradle plugin is applied BEFORE the AboutLibraries plugin.")
+        project.extensions.configure(AndroidComponentsExtension::class.java) {
+            it.onVariants { variant ->
+                block(project, extension, variant)
             }
         }
-    }
-}
-
-private fun configureAndroidTasks(project: Project, extension: AboutLibrariesExtension, @Suppress("DEPRECATION") variant: com.android.build.gradle.api.BaseVariant) {
-    val variantName = variant.name.replaceFirstChar { it.uppercase() }
-
-    val resultsResDirectory = project.layout.buildDirectory.dir("generated/aboutLibraries/${variant.name}/res/")
-    val resultsDirectory = resultsResDirectory.map { it.dir("raw/") }
-
-    // task to generate libraries, and their license into the build folder (not hooked to the build task)
-    project.tasks.configure("exportLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
-        it.variant.set(variant.name)
-        it.configureOutputFile(resultsDirectory.map { dir ->
-            @Suppress("DEPRECATION")
-            dir.file(extension.export.outputFileName.get())
-        })
-        it.configure()
-    }
-
-    // backwards compatibility, to be removed in v13.0.0
-    project.tasks.configure("generateLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
-        it.group = ""
-        it.deprecated.set(true)
-        it.variant.set(variant.name)
-        it.configureOutputFile(resultsDirectory.map { dir ->
-            @Suppress("DEPRECATION")
-            dir.file(extension.export.outputFileName.get())
-        })
-        it.configure()
-    }
-
-    // task to output libraries, and their license in CSV format to the CLI
-    project.tasks.configure("exportLibraries${variantName}", AboutLibrariesExportTask::class.java) {
-        it.variant.set(variant.name)
-        it.configure()
-    }
-
-    // task to output libraries, their license in CSV format and source to a given location
-    project.tasks.configure("exportComplianceLibraries${variantName}", AboutLibrariesExportComplianceTask::class.java) {
-        it.variant.set(variant.name)
-        it.projectDirectory.set(project.layout.projectDirectory)
-        it.configure()
     }
 }
 
@@ -117,18 +51,6 @@ private fun configureAndroidTasks(project: Project, extension: AboutLibrariesExt
 
     // task to generate libraries, and their license into the build folder (not hooked to the build task)
     project.tasks.configure("exportLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
-        it.variant.set(variant.name)
-        it.configureOutputFile(resultsDirectory.map { dir ->
-            @Suppress("DEPRECATION")
-            dir.file(extension.export.outputFileName.get())
-        })
-        it.configure()
-    }
-
-    // backwards compatibility, to be removed in v13.0.0
-    project.tasks.configure("generateLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
-        it.group = ""
-        it.deprecated.set(true)
         it.variant.set(variant.name)
         it.configureOutputFile(resultsDirectory.map { dir ->
             @Suppress("DEPRECATION")

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesTask.kt
@@ -12,7 +12,6 @@ import com.mikepenz.aboutlibraries.plugin.util.forLicense
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -34,10 +33,6 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
     @get:Optional
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
-
-    @get:Optional
-    @get:Input
-    abstract val deprecated: Property<Boolean>
 
     override fun getDescription(): String = "Exports dependency meta data from the current module.${variant.orNull?.let { " Filtered by variant: '$it'." } ?: ""}"
     override fun getGroup(): String = super.getGroup() ?: org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_GROUP
@@ -80,10 +75,6 @@ abstract class AboutLibrariesTask : BaseAboutLibrariesTask() {
 
     @TaskAction
     fun action() {
-        if (deprecated.isPresent && deprecated.get()) {
-            LOGGER.warn("`generateLibraryDefinitions${variant.orElse("").get()}` is deprecated. Please use `exportLibraryDefinitions${variant.orElse("").get()}` instead.")
-        }
-
         val output = outputFile.get().asFile
         if (!output.parentFile.exists()) {
             output.parentFile.mkdirs() // verify output exists

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -2,7 +2,6 @@ import com.mikepenz.gradle.utils.readPropertyOrElse
 
 plugins {
     id("com.mikepenz.convention.kotlin-multiplatform")
-    alias(baseLibs.plugins.androidKmpLibrary)
     id("com.mikepenz.convention.compose")
     id("com.mikepenz.aboutlibraries.plugin")
 }

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         namespace = "com.mikepenz.aboutlibraries.sample.shared"
         compileSdk = baseLibs.versions.compileSdk.get().toInt()
         minSdk = project.readPropertyOrElse("com.mikepenz.android.minSdk", baseLibs.versions.minSdk.get(), null)?.toInt()
+        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
     }
 
     listOf(


### PR DESCRIPTION
This pull request introduces significant breaking changes to the AboutLibraries Gradle plugin, primarily removing deprecated APIs and enforcing compatibility with Android Gradle Plugin (AGP) 7.0.0 or newer. The changes simplify the plugin's codebase by eliminating legacy support and tasks, and update documentation and build scripts to reflect these requirements.

**Plugin API and Compatibility Updates:**

* The plugin now requires AGP 7.0.0 or newer, enforced via a runtime check for `AndroidComponentsExtension`. Attempting to use the plugin with an older AGP version will log an error and abort plugin application. (`AboutLibrariesPluginAndroid.kt`, `AboutLibrariesPluginAndroidExtension.kt`) [[1]](diffhunk://#diff-41b16fcb805d12de410888d730f60484d73f557f4a8067618f649659d1bd140eR17-R29) [[2]](diffhunk://#diff-7db5ee92b8cf2f4ebf563ed53432130e902d2e07358252d1ea9471a8890fb58dL4-L93)
* All legacy APIs and support for pre-AGP 7 variants (`AppExtension`, `LibraryExtension`, and related code paths) have been removed. The plugin now exclusively uses the new AGP variants API. (`AboutLibrariesPluginAndroidExtension.kt`)

**Task Cleanup and Deprecation Removal:**

* The deprecated `generateLibraryDefinitions*` tasks and all related code (including the `deprecated` property and warnings) have been removed. Only the `exportLibraryDefinitions*` tasks remain. (`AboutLibrariesPluginAndroidExtension.kt`, `AboutLibrariesTask.kt`) [[1]](diffhunk://#diff-7db5ee92b8cf2f4ebf563ed53432130e902d2e07358252d1ea9471a8890fb58dL128-L139) [[2]](diffhunk://#diff-b65c8ee0bc2c71f736894c280543d579e429e92555e86f246b4aff4a411443a5L38-L41) [[3]](diffhunk://#diff-b65c8ee0bc2c71f736894c280543d579e429e92555e86f246b4aff4a411443a5L83-L86)

**Documentation and Build Script Updates:**

* The migration guide (`MIGRATION.md`) is updated to document the removal of deprecated tasks and the new AGP 7+ requirement.
* The sample shared module build script enables Android resources for KMP and removes the unused `androidKmpLibrary` plugin alias. (`sample/shared/build.gradle.kts`) [[1]](diffhunk://#diff-2baee6eefcc0da55ca2fd06be4257babca275b143b6de87e0be0ccc6d411c467L5) [[2]](diffhunk://#diff-2baee6eefcc0da55ca2fd06be4257babca275b143b6de87e0be0ccc6d411c467R24)

**CI Workflow Adjustment:**

* The CI workflow no longer attempts to build the staging variant, aligning with the updated plugin and build configuration. (`.github/workflows/ci.yml`)