### PR TITLE
docs: add description resource strings to keep file guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ with the following contents:
     tools:keep="@raw/aboutlibraries" />
 ```
 
+<details><summary><b>Legacy view-based UI: keeping description resource strings</b></summary>
+
+> **Note:** This only applies to the deprecated legacy view-based UI module (`aboutlibraries`). Consider migrating to the Compose-based UI instead.
+
 If you are using a custom `values/aboutlibraries_description.xml` to configure the library description UI, the string resources it defines will also be removed by resource shrinking. Add them to the keep file as well:
 
 ```xml
@@ -309,6 +313,8 @@ If you are using a custom `values/aboutlibraries_description.xml` to configure t
                 @string/aboutLibraries_description_showIcon,
                 @string/aboutLibraries_description_showVersion" />
 ```
+
+</details>
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -297,6 +297,19 @@ with the following contents:
     tools:keep="@raw/aboutlibraries" />
 ```
 
+If you are using a custom `values/aboutlibraries_description.xml` to configure the library description UI, the string resources it defines will also be removed by resource shrinking. Add them to the keep file as well:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries,
+                @string/aboutLibraries_showLicense,
+                @string/aboutLibraries_showVersion,
+                @string/aboutLibraries_description_name,
+                @string/aboutLibraries_description_showIcon,
+                @string/aboutLibraries_description_showVersion" />
+```
+
 </p>
 </details>
 


### PR DESCRIPTION
## Summary
- When using a custom `values/aboutlibraries_description.xml`, the string resources it defines (e.g. `aboutLibraries_showLicense`, `aboutLibraries_description_name`, etc.) are also removed by optimized resource shrinking (enabled by default in AGP 9.0).
- Documents that these strings should be included in the resource keep file alongside `@raw/aboutlibraries`.

## Context
Encountered this issue after upgrading to AGP 9.0. The `aboutlibraries.json` keep rule was already documented, but the description string resources were silently stripped, causing the library description UI configuration to be lost at runtime.

## Test plan
- [x] Verified the documented keep file entries match the string resource names used in `aboutlibraries_description.xml`