### PR TITLE
chore(ci): enable automerge for gradle/maven patch and minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,24 @@
   "packageRules": [
     {
       "matchManagers": [
+        "gradle",
+        "gradle-wrapper",
+        "maven"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "groupName": "gradle/maven non-major updates",
+      "labels": [
+        "dependencies",
+        "gradle"
+      ]
+    },
+    {
+      "matchManagers": [
         "github-actions"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

- Add a `packageRule` for `gradle`, `gradle-wrapper`, and `maven` managers
- Enable `automerge: true` and `platformAutomerge: true` for `patch` and `minor` updates