### PR TITLE
Restore empty color-v21 divider resources

### DIFF
--- a/aboutlibraries/src/main/res/color-v21/description_divider.xml
+++ b/aboutlibraries/src/main/res/color-v21/description_divider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.17" android:color="?attr/colorOnSurface" />
+</selector>

--- a/aboutlibraries/src/main/res/color-v21/opensource_divider.xml
+++ b/aboutlibraries/src/main/res/color-v21/opensource_divider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.17" android:color="?attr/colorOnSurface" />
+</selector>


### PR DESCRIPTION
## Summary
- `aboutlibraries/src/main/res/color-v21/description_divider.xml` and `opensource_divider.xml` were committed as 0-byte files in 41f1a91, breaking AAR resource compilation for downstream consumers of `com.mikepenz:aboutlibraries:14.0.0` with `Vorzeitiges Dateiende` / premature end of file.
- Restored the original `<selector>` content (matching the API <21 fallback in `res/color/`).

Fixes #1330

## Test plan
- [ ] `./gradlew :aboutlibraries:assembleRelease` succeeds
- [ ] Downstream consumer using `com.mikepenz:aboutlibraries` builds without `AarResourcesCompilerTransform` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)