### PR TITLE
chore(renovate): extend shared convention preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,60 +1,6 @@
 {
-  "$schema": "https://docs.renovateapp.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "pinDigests": true,
-  "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "labels": [
-      "dependencies",
-      "security"
-    ],
-    "automerge": false,
-    "minimumReleaseAge": "0 days"
-  },
-  "labels": [
-    "dependencies"
-  ],
-  "minimumReleaseAge": "7 days",
-  "schedule": [
-    "before 6am on Monday"
-  ],
-  "timezone": "Europe/Berlin",
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gradle",
-        "gradle-wrapper",
-        "maven"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "platformAutomerge": true,
-      "groupName": "gradle/maven non-major updates",
-      "labels": [
-        "dependencies",
-        "gradle"
-      ]
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "groupName": "GitHub Actions updates",
-      "labels": [
-        "dependencies",
-        "github-actions"
-      ]
-    }
-  ]
+    "$schema": "https://docs.renovateapp.com/renovate-schema.json",
+    "extends": [
+        "local>mikepenz/convention"
+    ]
 }


### PR DESCRIPTION
## Summary
- Replaces inline Renovate config with the shared `local>mikepenz/convention` preset
- Aligns this repo with https://github.com/mikepenz/agent-approver/blob/main/renovate.json

## Test plan
- [ ] Renovate dry-run / next scheduled run picks up the new preset