### PR TITLE
chore(renovate): extend shared convention preset

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(baseLibs.plugins.conventionPlugin)
     alias(baseLibs.plugins.dokka)
     alias(baseLibs.plugins.mavenPublish)
-    id("com.gradle.plugin-publish") version "1.3.1" apply false
+    id("com.gradle.plugin-publish") version "2.1.1" apply false
 }
 
 buildscript {

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/GroovyDslFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/GroovyDslFunctionalTest.kt
@@ -1,0 +1,216 @@
+package com.mikepenz.aboutlibraries.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Functional tests verifying the AboutLibraries plugin works correctly with Groovy DSL build scripts.
+ *
+ * Groovy's `DefaultGroovyMethods.collect(Object, Closure)` shadows the plugin's
+ * `collect(Action<CollectorConfig>)` method, so the standard `collect { configPath = ... }`
+ * syntax does NOT work. These tests verify working alternatives.
+ *
+ * See: https://github.com/mikepenz/AboutLibraries/issues/1328
+ */
+class GroovyDslFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    @Test
+    fun `groovy dsl - collect block closure syntax fails due to groovy collect shadowing`() {
+        // This test documents the BROKEN syntax that users hit in issue #1328.
+        // Groovy's built-in `collect(Closure)` on Object shadows the plugin method.
+        setupGroovyProject(
+            projectDir,
+            """
+            aboutLibraries {
+                offlineMode = true
+                collect {
+                    configPath = file("config")
+                }
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .buildAndFail()
+
+        // The closure is interpreted by Groovy's collect, not the plugin's collect
+        val output = result.output
+        assertTrue(
+            output.contains("MissingPropertyException") || output.contains("unknown property"),
+            "Should fail because Groovy's built-in collect() shadows the plugin method. Output: $output"
+        )
+    }
+
+    @Test
+    fun `groovy dsl - getCollect() dot notation works`() {
+        // RECOMMENDED workaround: use getCollect() to bypass Groovy's collect method
+        setupGroovyProject(
+            projectDir,
+            """
+            aboutLibraries {
+                offlineMode = true
+                getCollect().configPath = file("config")
+                getCollect().fetchRemoteLicense = false
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+    }
+
+    @Test
+    fun `groovy dsl - collect property accessor dot notation works`() {
+        // Alternative: access the `collect` property directly (Groovy property access, not method call)
+        setupGroovyProject(
+            projectDir,
+            """
+            aboutLibraries {
+                offlineMode = true
+                collect.configPath = file("config")
+                collect.fetchRemoteLicense = false
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+    }
+
+    @Test
+    fun `groovy dsl - license and library blocks work normally`() {
+        // `license` and `library` don't conflict with Groovy built-ins
+        setupGroovyProject(
+            projectDir,
+            """
+            import com.mikepenz.aboutlibraries.plugin.DuplicateMode
+            import com.mikepenz.aboutlibraries.plugin.DuplicateRule
+            import com.mikepenz.aboutlibraries.plugin.StrictMode
+
+            aboutLibraries {
+                offlineMode = true
+                license {
+                    strictMode = StrictMode.WARN
+                    allowedLicenses.addAll("Apache-2.0", "MIT")
+                }
+                library {
+                    duplicationMode = DuplicateMode.MERGE
+                    duplicationRule = DuplicateRule.EXACT
+                }
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+    }
+
+    @Test
+    fun `groovy dsl - full configuration with getCollect workaround`() {
+        // Full configuration example combining all blocks
+        setupGroovyProject(
+            projectDir,
+            """
+            import com.mikepenz.aboutlibraries.plugin.DuplicateMode
+            import com.mikepenz.aboutlibraries.plugin.DuplicateRule
+            import com.mikepenz.aboutlibraries.plugin.StrictMode
+
+            aboutLibraries {
+                offlineMode = true
+
+                // Use getCollect() or collect. to configure the collector
+                getCollect().configPath = file("config")
+                getCollect().fetchRemoteLicense = false
+
+                export {
+                    prettyPrint = true
+                }
+
+                license {
+                    strictMode = StrictMode.WARN
+                    allowedLicenses.addAll("Apache-2.0", "MIT")
+                }
+
+                library {
+                    duplicationMode = DuplicateMode.MERGE
+                    duplicationRule = DuplicateRule.EXACT
+                }
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+    }
+
+    private fun setupGroovyProject(
+        projectDir: File,
+        aboutLibrariesBlock: String,
+    ) {
+        // Use Groovy DSL settings file
+        File(projectDir, "settings.gradle").writeText(
+            """
+            rootProject.name = 'test-groovy-project'
+            """.trimIndent()
+        )
+
+        // Create a config directory (for configPath tests)
+        File(projectDir, "config").mkdirs()
+
+        // Groovy DSL build file
+        File(projectDir, "build.gradle").writeText(
+            """
+            plugins {
+                id 'java-library'
+                id 'com.mikepenz.aboutlibraries.plugin'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation 'com.google.code.gson:gson:2.10.1'
+                implementation 'org.slf4j:slf4j-api:2.0.9'
+            }
+
+            $aboutLibrariesBlock
+            """.trimIndent()
+        )
+    }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,60 +1,6 @@
 {
-  "$schema": "https://docs.renovateapp.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "pinDigests": true,
-  "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "labels": [
-      "dependencies",
-      "security"
-    ],
-    "automerge": false,
-    "minimumReleaseAge": "0 days"
-  },
-  "labels": [
-    "dependencies"
-  ],
-  "minimumReleaseAge": "7 days",
-  "schedule": [
-    "before 6am on Monday"
-  ],
-  "timezone": "Europe/Berlin",
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gradle",
-        "gradle-wrapper",
-        "maven"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "platformAutomerge": true,
-      "groupName": "gradle/maven non-major updates",
-      "labels": [
-        "dependencies",
-        "gradle"
-      ]
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "groupName": "GitHub Actions updates",
-      "labels": [
-        "dependencies",
-        "github-actions"
-      ]
-    }
-  ]
+    "$schema": "https://docs.renovateapp.com/renovate-schema.json",
+    "extends": [
+        "local>mikepenz/convention"
+    ]
 }


### PR DESCRIPTION
## Summary
- Replaces inline Renovate config with the shared `local>mikepenz/convention` preset
- Aligns this repo with https://github.com/mikepenz/agent-approver/blob/main/renovate.json

## Test plan
- [ ] Renovate dry-run / next scheduled run picks up the new preset