### PR TITLE
perf(plugin): single-pass dep walk, typed coordinate map, version-slot POM batching

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
@@ -40,11 +40,16 @@ abstract class AboutLibrariesExportComplianceTask : BaseAboutLibrariesTask() {
             @Suppress("UnstableApiUsage")
             project.isolated.rootProject.projectDirectory
         }
+        // When the user supplies an export path we resolve it relative to the root project.
+        // Otherwise we fall back to a dedicated subdirectory under the current project's build
+        // folder. Defaulting to the root project directory would make Gradle treat the entire
+        // project tree as this task's @OutputDirectory, which both bloats output snapshotting
+        // and makes stale-output cleanup unsafe for unrelated files.
         exportPath.convention(
             project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}")
                 .orElse(project.providers.gradleProperty(PROP_EXPORT_PATH))
                 .map { path -> rootDir.dir(path) }
-                .orElse(rootDir)
+                .orElse(project.layout.buildDirectory.dir("aboutlibraries/export-compliance"))
         )
     }
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExportComplianceTask.kt
@@ -4,49 +4,49 @@ import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP
 import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_EXPORT_PATH
 import com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension.Companion.PROP_PREFIX
 import com.mikepenz.aboutlibraries.plugin.mapping.SpdxLicense
-import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
+import org.gradle.work.DisableCachingByDefault
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
+@DisableCachingByDefault(because = "Writes ad-hoc CSV/TXT plus copied artifact files to a user-supplied directory; not worth caching")
 abstract class AboutLibrariesExportComplianceTask : BaseAboutLibrariesTask() {
-
-    @get:InputDirectory
-    abstract val projectDirectory: DirectoryProperty
 
     override fun getDescription(): String = "Writes all libraries with their source and their license in CSV format to the configured directory"
     override fun getGroup(): String = "Help"
 
-    @Input
-    @Optional
-    val exportPath: Provider<Directory> = project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}")
-        .map { path -> projectDirectory.get().dir(path) }
-        .orElse(project.providers.gradleProperty(PROP_EXPORT_PATH).map { path ->
-            projectDirectory.get().dir(path)
-        })
-        .orElse(
-            if (GradleVersion.current() < GradleVersion.version("8.8")) {
-                LOGGER.info("Fallback to non project isolated safe API for root directory.")
-                // noinspection GradleProjectIsolation
-                project.rootProject.layout.projectDirectory.dir(".")
-            } else {
-                @Suppress("UnstableApiUsage")
-                project.isolated.rootProject.projectDirectory.dir(".")
-            }
-        )
+    @get:OutputDirectory
+    abstract val exportPath: DirectoryProperty
 
     @Input
     val artifactGroups: Provider<String> = project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_ARTIFACT_GROUPS}").orElse(
         project.providers.gradleProperty(PROP_EXPORT_ARTIFACT_GROUPS)
     ).orElse("")
+
+    override fun configure() {
+        super.configure()
+        val rootDir = if (GradleVersion.current() < GradleVersion.version("8.8")) {
+            LOGGER.info("Fallback to non project isolated safe API for root directory.")
+            // noinspection GradleProjectIsolation
+            project.rootProject.layout.projectDirectory
+        } else {
+            @Suppress("UnstableApiUsage")
+            project.isolated.rootProject.projectDirectory
+        }
+        exportPath.convention(
+            project.providers.gradleProperty("${PROP_PREFIX}${PROP_EXPORT_PATH}")
+                .orElse(project.providers.gradleProperty(PROP_EXPORT_PATH))
+                .map { path -> rootDir.dir(path) }
+                .orElse(rootDir)
+        )
+    }
 
     @TaskAction
     fun action() {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -72,7 +72,6 @@ private fun configureAndroidTasks(project: Project, extension: AboutLibrariesExt
     // task to output libraries, their license in CSV format and source to a given location
     project.tasks.configure("exportComplianceLibraries${variantName}", AboutLibrariesExportComplianceTask::class.java) {
         it.variant.set(variant.name)
-        it.projectDirectory.set(project.layout.projectDirectory)
         it.configure()
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -6,15 +6,16 @@ import com.mikepenz.aboutlibraries.plugin.util.DependencyCollector
 import com.mikepenz.aboutlibraries.plugin.util.DependencyCoordinates
 import com.mikepenz.aboutlibraries.plugin.util.DependencyData
 import com.mikepenz.aboutlibraries.plugin.util.LibraryPostProcessor
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -23,13 +24,22 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 import org.slf4j.LoggerFactory
 import java.io.File
 
+@DisableCachingByDefault(because = "Abstract base task; concrete subclasses opt in via @CacheableTask")
 abstract class BaseAboutLibrariesTask : DefaultTask() {
 
-    @Internal
-    protected val extension = project.extensions.findByType(AboutLibrariesExtension::class.java)!!
+    /**
+     * Getter-only accessor for the project extension. Implemented as a `get()` (not a backing
+     * field) so the extension instance is not serialized into the configuration cache. Each
+     * call resolves it fresh from `project.extensions`, which is only safe during the
+     * configuration phase — every consumer below is field-initializer or [configure] scoped.
+     */
+    @get:Internal
+    protected val extension: AboutLibrariesExtension
+        get() = project.extensions.getByType(AboutLibrariesExtension::class.java)
 
     @Input
     val collectAll = extension.collect.all
@@ -69,15 +79,13 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val allowedLicensesMap = extension.license.allowedLicensesMap
 
     @Input
-    open val offlineMode = extension.offlineMode
+    open val offlineMode: Property<Boolean> = extension.offlineMode
 
-    @Suppress("HasPlatformType")
     @Input
-    open val fetchRemoteLicense = extension.collect.fetchRemoteLicense.map { it && !offlineMode.get() }
+    open val fetchRemoteLicense: Provider<Boolean> = extension.collect.fetchRemoteLicense.map { it && !offlineMode.get() }
 
-    @Suppress("HasPlatformType")
     @Input
-    open val fetchRemoteFunding = extension.collect.fetchRemoteFunding.map { it && !offlineMode.get() }
+    open val fetchRemoteFunding: Provider<Boolean> = extension.collect.fetchRemoteFunding.map { it && !offlineMode.get() }
 
     @Input
     val additionalLicenses = extension.license.additionalLicenses
@@ -107,27 +115,31 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     internal abstract val configurationNames: ListProperty<String>
 
     /**
-     * Maps configuration name → pipe-separated "group:artifact:version" coordinate keys.
+     * Maps configuration name → list of [DependencyCoordinates] for all external module
+     * dependencies in that configuration.
      *
-     * Marked `@Input` so the task build-cache key reflects which dependency versions are present.
-     * A version change produces a different value and triggers a cache miss.
+     * Stored as a typed `MapProperty<String, List<DependencyCoordinates>>` (rather than a
+     * pipe-encoded `MapProperty<String, String>`) so the value is consumed without any
+     * string parsing at execution time. [DependencyCoordinates] is `java.io.Serializable`,
+     * which is all the configuration cache requires.
      *
-     * Populated lazily via `resolutionResult.rootComponent.map {}` — fully config-cache safe.
+     * Marked `@Input` so the task build-cache key reflects which dependency versions are
+     * present — a version change produces a different value and triggers a cache miss.
      */
     @get:Input
-    internal abstract val configToCoordinateKeys: MapProperty<String, String>
+    internal abstract val configToCoordinates: MapProperty<String, List<DependencyCoordinates>>
 
     /**
      * Maps "group:artifact:version" → absolute path of the resolved POM file for every external
      * module dependency (including transitively discovered parent POMs).
      *
-     * Populated at configuration time via detached configurations with `@pom` notation, wrapped
-     * in a `project.provider {}` so the actual resolution is deferred until Gradle realises this
-     * property. The resolution is evaluated at configuration time (during config-cache store),
-     * so no `Project` access happens at execution time.
+     * Populated eagerly during [configure] via detached configurations + parent POM walking.
+     * Eager evaluation guarantees no `Configuration` instances are captured into provider
+     * closures and serialized into the configuration cache.
      *
-     * Approach mirrors google/play-services-plugins#365 (`oss-licenses-plugin`), which pre-resolves
-     * artifact-to-file mappings at configuration time and exposes them as a lazy task property.
+     * Approach mirrors google/play-services-plugins#365 (`oss-licenses-plugin`), which
+     * pre-resolves artifact-to-file mappings at configuration time and exposes them as a lazy
+     * task property.
      *
      * Marked `@Internal` because the actual file content is tracked via [pomFiles]; this map
      * only stores the coordinate→path lookup for execution-time use.
@@ -219,108 +231,102 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
 
         configurationNames.set(selectedConfigs.map { it.name })
 
+        // Single-pass dependency-graph walk: compute per-configuration coordinates AND the
+        // union set used for POM resolution in one traversal per configuration. The previous
+        // implementation walked the graph twice (once for `configToCoordinateKeys`, once
+        // inside `resolvePomFiles`).
         val capturedIncludePlatform = includePlatform.get()
+        val collector = DependencyCollector(capturedIncludePlatform)
+        val perConfigCoords = LinkedHashMap<String, List<DependencyCoordinates>>(selectedConfigs.size)
+        val unionCoords = LinkedHashSet<DependencyCoordinates>()
         for (config in selectedConfigs) {
-            // Per-config coordinate keys: resolved lazily from the resolution result.
-            // Encoded as "|"-separated "group:artifact:version" strings so the MapProperty value
-            // type stays a plain String — fully config-cache serializable.
-            val coordKeysProvider = config.incoming.resolutionResult.rootComponent.map { root ->
-                DependencyCollector(capturedIncludePlatform)
-                    .loadDependencyCoordinates(root)
-                    .map { it.cacheKey() }
-                    .sorted()
-                    .joinToString("|")
-            }
-            configToCoordinateKeys.put(config.name, coordKeysProvider)
+            val root = config.incoming.resolutionResult.rootComponent.get()
+            val coords = collector.loadDependencyCoordinates(root)
+            perConfigCoords[config.name] = coords.toList()
+            unionCoords.addAll(coords)
         }
+        configToCoordinates.set(perConfigCoords)
 
-        // Populate pomFileMap via detached configurations + parent POM walking, wrapped in
-        // `project.provider {}`. The provider is evaluated at configuration time (when the value
-        // is realised during config-cache store), so all project access happens during the
-        // configuration phase — never at task execution time.
-        //
-        // This pattern mirrors google/play-services-plugins#365 (the oss-licenses-plugin), which
-        // uses the same approach for config-cache-compatible POM resolution.
-        pomFileMap.putAll(project.provider { resolvePomFiles(selectedConfigs) })
+        // Resolve POM files eagerly at configuration time. Eager resolution avoids capturing
+        // any `Configuration` references inside a `project.provider {}` closure (which would
+        // otherwise live in the configuration-cache state until store time). All Gradle API
+        // access happens here, in [configure], which itself runs lazily via the
+        // `tasks.named { … }` task-realization mechanism.
+        val resolvedPomMap = if (unionCoords.isEmpty()) emptyMap() else resolvePomFiles(unionCoords)
+        pomFileMap.set(resolvedPomMap)
 
         // Register the actual POM files as @InputFiles for content-addressed UP-TO-DATE tracking.
-        // Derive from `pomFileMap` (rather than re-running `resolvePomFiles`) so the heavy
-        // resolution happens exactly once.  `MapProperty.map {}` shares the underlying value with
-        // any other consumer of the same property.
-        pomFiles.from(pomFileMap.map { map -> map.values.map { path -> File(path) } })
+        pomFiles.from(resolvedPomMap.values.map { File(it) })
         pomFiles.finalizeValueOnRead()
     }
 
     /**
-     * Resolves POM files for every external module dependency in [configs], including parent
-     * POMs reachable via the `<parent>` element.
+     * Resolves POM files for every coordinate in [initialCoordinates], including parent POMs
+     * reachable via the `<parent>` element.
      *
-     * Approach (similar to the OLD detached-configuration pattern but evaluated at configuration
-     * time so it remains config-cache safe):
+     * Detached configurations are batched in **version slots** to keep their count bounded by
+     * the maximum number of conflicting versions per `group:artifact`, rather than the total
+     * coordinate count. Slot 0 contains the first version of each `g:a`, slot 1 the second,
+     * and so on. Within a slot every coordinate is unique by `g:a`, so Gradle's conflict
+     * resolver cannot silently discard versions.
      *
-     *  1. Walk every [configs] resolution result and gather module coordinates with
-     *     [DependencyCollector.loadDependencyCoordinates] (this also picks up platform / BOM
-     *     dependencies, which are otherwise filtered out by attribute-typed artifact views).
-     *
-     *  2. Fetch each coordinate's POM via a detached configuration using `@pom` notation. This is
-     *     the only Gradle API that reliably returns POM files for all module types (regular libs,
-     *     platforms, BOMs, classifier deps).
-     *
-     *  3. Parse each fetched POM with [MavenXpp3Reader], collect parent coordinates, queue any
-     *     unseen parents, and repeat steps 2-3 until the queue is empty. This pre-resolves the
-     *     full parent-POM hierarchy so the execution-time Maven Model Builder can produce the
-     *     same library metadata (developers, organization, scm, …) the OLD code produced via
-     *     its on-demand `ModelResolver`.
+     * Phase 1 fetches the initial union of coordinates collected from every configuration.
+     * Phase 2 repeatedly drains the parent-POM queue and fetches each level in slot batches
+     * until no new parents are discovered.
      */
-    private fun resolvePomFiles(configs: List<Configuration>): Map<String, String> {
-        val capturedIncludePlatform = includePlatform.get()
-
-        // Phase 1: collect coordinates for every resolved external dependency.
-        val initialCoordinates = mutableSetOf<DependencyCoordinates>()
-        for (config in configs) {
-            val root = config.incoming.resolutionResult.rootComponent.get()
-            DependencyCollector(capturedIncludePlatform)
-                .loadDependencyCoordinates(root)
-                .forEach { initialCoordinates.add(it) }
-        }
-        if (initialCoordinates.isEmpty()) return emptyMap()
-
-        val pomMap = mutableMapOf<String, String>()
+    private fun resolvePomFiles(initialCoordinates: Set<DependencyCoordinates>): Map<String, String> {
+        val pomMap = LinkedHashMap<String, String>(initialCoordinates.size * 2)
         val parentsToFetch = ArrayDeque<DependencyCoordinates>()
-        val attempted = mutableSetOf<String>()
+        val attempted = HashSet<String>(initialCoordinates.size * 2)
 
-        // Phase 2: fetch the initial coordinates. Coordinates are aggregated across multiple
-        // configurations (e.g. debugCompileClasspath + releaseRuntimeClasspath), which can
-        // legitimately contribute the same `group:artifact` at different versions. Adding all
-        // versions to a single detached configuration would let Gradle's conflict resolver
-        // pick one version and silently discard the others. Partition by `group:artifact`:
-        // batch all g:a that have a single version (the common case — fast path), and fetch any
-        // g:a with multiple versions one coordinate at a time (same approach as Phase 3).
-        val byGa = initialCoordinates.groupBy { "${it.group}:${it.artifact}" }
-        val (uniqueGa, conflictingGa) = byGa.values.partition { it.size == 1 }
-        fetchPomBatch(uniqueGa.flatten(), pomMap, parentsToFetch, attempted)
-        conflictingGa.flatten().forEach { coord ->
-            fetchPomBatch(listOf(coord), pomMap, parentsToFetch, attempted)
-        }
+        // Phase 1: initial coordinates.
+        fetchInVersionSlots(initialCoordinates, pomMap, parentsToFetch, attempted)
 
-        // Phase 3: fetch parent POMs ONE AT A TIME. Parents from different dependencies can
-        // legitimately reference different versions of the same group:artifact (e.g.
-        // guava-parent:33.3.1-jre vs guava-parent:26.0-android). Adding both to a single detached
-        // configuration causes Gradle to silently pick one and discard the other, so each parent
-        // gets its own detached configuration.
+        // Phase 2: parent POMs, drained one level at a time so parents-of-parents land in
+        // the next iteration. Each level is itself batched into version slots.
         while (parentsToFetch.isNotEmpty()) {
-            val coord = parentsToFetch.removeFirst()
-            if (!attempted.add(coord.cacheKey())) continue
-            fetchPomBatch(listOf(coord), pomMap, parentsToFetch, attempted)
+            val level = ArrayList<DependencyCoordinates>(parentsToFetch.size)
+            while (parentsToFetch.isNotEmpty()) level.add(parentsToFetch.removeFirst())
+            fetchInVersionSlots(level, pomMap, parentsToFetch, attempted)
         }
 
         return pomMap
     }
 
     /**
+     * Partitions [coordinates] by `group:artifact` and fetches them in version slots: each
+     * slot becomes a single detached configuration containing at most one version per
+     * `group:artifact`, so Gradle's conflict resolver leaves every requested version intact.
+     */
+    private fun fetchInVersionSlots(
+        coordinates: Collection<DependencyCoordinates>,
+        pomMap: MutableMap<String, String>,
+        parentsToFetch: ArrayDeque<DependencyCoordinates>,
+        attempted: MutableSet<String>,
+    ) {
+        if (coordinates.isEmpty()) return
+        val byGa = LinkedHashMap<String, ArrayList<DependencyCoordinates>>()
+        for (coord in coordinates) {
+            if (coord.cacheKey() in attempted) continue
+            byGa.getOrPut("${coord.group}:${coord.artifact}") { ArrayList(1) }.add(coord)
+        }
+        if (byGa.isEmpty()) return
+        val maxSlots = byGa.values.maxOf { it.size }
+        for (slot in 0 until maxSlots) {
+            val batch = ArrayList<DependencyCoordinates>(byGa.size)
+            for (versions in byGa.values) {
+                if (slot < versions.size) batch.add(versions[slot])
+            }
+            if (batch.isNotEmpty()) fetchPomBatch(batch, pomMap, parentsToFetch, attempted)
+        }
+    }
+
+    /**
      * Resolves the [batch] of POM coordinates into a single detached configuration, populating
      * [pomMap] with `<group:artifact:version> → absolute path` entries and queueing any newly
      * discovered parent coordinates onto [parentsToFetch].
+     *
+     * The caller guarantees [batch] contains at most one version per `group:artifact`.
      */
     private fun fetchPomBatch(
         batch: List<DependencyCoordinates>,
@@ -336,6 +342,8 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
         val detached = project.configurations.detachedConfiguration(*pomDeps).apply {
             isCanBeConsumed = false
             isCanBeResolved = true
+            // `@pom` deps don't pull transitives, but disabling explicitly skips graph-build.
+            isTransitive = false
         }
 
         try {
@@ -347,10 +355,10 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
                 val file = artifact.file
                 pomMap[key] = file.absolutePath
 
-                // Parse the POM to discover the parent and queue it for individual fetching.
+                // Parse the POM to discover the parent and queue it for the next level.
                 val parent = readParent(file) ?: continue
                 val parentCoords = DependencyCoordinates(parent.first, parent.second, parent.third)
-                if (!attempted.contains(parentCoords.cacheKey())) {
+                if (parentCoords.cacheKey() !in attempted) {
                     parentsToFetch.add(parentCoords)
                 }
             }
@@ -375,7 +383,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     /**
      * Builds a [LibraryPostProcessor] using only serialized task properties — no [project] access.
      *
-     * Both [configToCoordinateKeys] and [pomFileMap] are `@Input` properties whose values were
+     * Both [configToCoordinates] and [pomFileMap] are task properties whose values were
      * computed at configuration time. At execution time we simply read them, making the method
      * fully compatible with Gradle's configuration cache and project-isolation requirements.
      */
@@ -391,25 +399,19 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
 
         if (LOGGER.isDebugEnabled) LOGGER.debug("==> ABOUTLIBRARIES: Resolving dependency data at execution time")
 
-        val resolvedKeyMap: Map<String, String> = configToCoordinateKeys.get()
+        val resolvedPerConfigCoords: Map<String, List<DependencyCoordinates>> = configToCoordinates.get()
         val resolvedPomFileMap: Map<String, File> = pomFileMap.get().mapValues { (_, path) -> File(path) }
 
         // Parse each unique coordinate exactly once across all configurations. Without this,
         // overlapping classpaths (e.g. compile + runtime sharing the same deps) would re-run
         // the Maven Model Builder for each occurrence — a measurable execution-time cost on
         // larger projects.
-        val perConfigCoords: Map<String, Set<DependencyCoordinates>> = resolvedKeyMap.mapValues { (_, coordKeysStr) ->
-            coordKeysStr.split("|").filter { it.isNotEmpty() }.mapNotNull { key ->
-                val parts = key.split(":")
-                if (parts.size == 3) DependencyCoordinates(parts[0], parts[1], parts[2]) else null
-            }.toSet()
-        }
-        val allCoords: Set<DependencyCoordinates> = perConfigCoords.values.flatten().toSet()
-        val parsedByKey: Map<String, DependencyData> = DependencyCollector(includePlatform.get())
+        val allCoords: Set<DependencyCoordinates> = resolvedPerConfigCoords.values.flatten().toSet()
+        val parsedByCoord: Map<DependencyCoordinates, DependencyData> = DependencyCollector(includePlatform.get())
             .loadDependenciesFromCoordinates(allCoords, resolvedPomFileMap)
-            .associateBy { it.dependencyCoordinates.cacheKey() }
-        val variantToDependencyData = perConfigCoords.mapValues { (_, coords) ->
-            coords.mapNotNull { parsedByKey[it.cacheKey()] }
+            .associateBy { it.dependencyCoordinates }
+        val variantToDependencyData = resolvedPerConfigCoords.mapValues { (_, coords) ->
+            coords.mapNotNull { parsedByCoord[it] }
         }
 
         if (LOGGER.isDebugEnabled) LOGGER.debug("==> ABOUTLIBRARIES: Dependency resolution complete")

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -241,8 +241,12 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
         val unionCoords = LinkedHashSet<DependencyCoordinates>()
         for (config in selectedConfigs) {
             val root = config.incoming.resolutionResult.rootComponent.get()
-            val coords = collector.loadDependencyCoordinates(root)
-            perConfigCoords[config.name] = coords.toList()
+            // Sort per-config coordinates by cacheKey() so the @Input map value is stable across
+            // runs and machines. The dependency-graph walk visits children in
+            // `ResolvedComponentResult.getDependencies()` iteration order, which is not formally
+            // specified — sorting is what guarantees a portable build-cache key.
+            val coords = collector.loadDependencyCoordinates(root).sortedBy { it.cacheKey() }
+            perConfigCoords[config.name] = coords
             unionCoords.addAll(coords)
         }
         configToCoordinates.set(perConfigCoords)
@@ -283,9 +287,12 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
         fetchInVersionSlots(initialCoordinates, pomMap, parentsToFetch, attempted)
 
         // Phase 2: parent POMs, drained one level at a time so parents-of-parents land in
-        // the next iteration. Each level is itself batched into version slots.
+        // the next iteration. Each level is itself batched into version slots. Drain into a
+        // `LinkedHashSet` so sibling artifacts that share the same parent (e.g. several modules
+        // of one project pointing at the same parent POM) collapse to a single fetch instead of
+        // landing in separate slots.
         while (parentsToFetch.isNotEmpty()) {
-            val level = ArrayList<DependencyCoordinates>(parentsToFetch.size)
+            val level = LinkedHashSet<DependencyCoordinates>(parentsToFetch.size)
             while (parentsToFetch.isNotEmpty()) level.add(parentsToFetch.removeFirst())
             fetchInVersionSlots(level, pomMap, parentsToFetch, attempted)
         }

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/ConfigurationCacheTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/ConfigurationCacheTest.kt
@@ -267,6 +267,217 @@ class ConfigurationCacheTest {
         assertFalse(output.contains("io.mockk:mockk"), "mockk from desktopTest classpath must NOT leak into output")
     }
 
+    /**
+     * The previous CC tests only proved the *reuse* path. This locks in the *invalidation* path:
+     * when a declared dependency version changes, the @Input `configToCoordinates` map value
+     * differs, so both the configuration cache entry AND the task up-to-date state must
+     * invalidate, the task must re-run, and the new version must show up in the output.
+     */
+    @Test
+    fun `configuration cache invalidates when dependency version changes`() {
+        File(projectDir, "settings.gradle.kts").writeText("""rootProject.name = "test-project"""")
+        val buildFile = File(projectDir, "build.gradle.kts")
+        fun writeBuild(gsonVersion: String) {
+            buildFile.writeText(
+                """
+                plugins {
+                    id("java-library")
+                    id("com.mikepenz.aboutlibraries.plugin")
+                }
+                repositories { mavenCentral() }
+                dependencies {
+                    implementation("com.google.code.gson:gson:$gsonVersion")
+                }
+                aboutLibraries { offlineMode = true }
+                """.trimIndent()
+            )
+        }
+
+        writeBuild("2.11.0")
+        @Suppress("WithPluginClasspathUsage")
+        val first = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--configuration-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertTrue(first.output.contains("Configuration cache entry stored"))
+        assertEquals(TaskOutcome.SUCCESS, first.task(":exportLibraryDefinitions")?.outcome)
+        val firstOutput = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+        assertTrue(firstOutput.contains("\"artifactVersion\":\"2.11.0\""), "First run should contain gson 2.11.0")
+
+        // Bump the version. CC must invalidate, task must re-run, output must reflect 2.10.1.
+        writeBuild("2.10.1")
+        @Suppress("WithPluginClasspathUsage")
+        val second = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--configuration-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertFalse(
+            second.output.contains("Configuration cache entry reused"),
+            "CC must NOT be reused after a dependency version change. Output: ${second.output}"
+        )
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            second.task(":exportLibraryDefinitions")?.outcome,
+            "Task must re-execute after dependency version change"
+        )
+        val secondOutput = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+        assertTrue(secondOutput.contains("\"artifactVersion\":\"2.10.1\""), "Second run should reflect gson 2.10.1")
+        assertFalse(secondOutput.contains("\"artifactVersion\":\"2.11.0\""), "Stale 2.11.0 must not remain")
+    }
+
+    /**
+     * Adding a new `exclusionPatterns` entry must invalidate the CC entry (the @Input
+     * `exclusionPatterns` value differs), re-run the task, and remove the matching library
+     * from the output JSON.
+     */
+    @Test
+    fun `configuration cache invalidates when exclusionPatterns is added`() {
+        File(projectDir, "settings.gradle.kts").writeText("""rootProject.name = "test-project"""")
+        val buildFile = File(projectDir, "build.gradle.kts")
+        fun writeBuild(withExclusion: Boolean) {
+            val exclusionBlock = if (withExclusion) {
+                """library { exclusionPatterns.add("com\\.google\\.code\\.gson:.*") }"""
+            } else ""
+            buildFile.writeText(
+                """
+                plugins {
+                    id("java-library")
+                    id("com.mikepenz.aboutlibraries.plugin")
+                }
+                repositories { mavenCentral() }
+                dependencies {
+                    implementation("com.google.code.gson:gson:2.11.0")
+                    implementation("org.slf4j:slf4j-api:2.0.16")
+                }
+                aboutLibraries {
+                    offlineMode = true
+                    $exclusionBlock
+                }
+                """.trimIndent()
+            )
+        }
+
+        writeBuild(withExclusion = false)
+        @Suppress("WithPluginClasspathUsage")
+        val first = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--configuration-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertTrue(first.output.contains("Configuration cache entry stored"))
+        assertTrue(
+            File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+                .contains("com.google.code.gson:gson"),
+            "gson should be present before exclusion"
+        )
+
+        writeBuild(withExclusion = true)
+        @Suppress("WithPluginClasspathUsage")
+        val second = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--configuration-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertFalse(
+            second.output.contains("Configuration cache entry reused"),
+            "CC must invalidate when exclusionPatterns changes. Output: ${second.output}"
+        )
+        assertEquals(TaskOutcome.SUCCESS, second.task(":exportLibraryDefinitions")?.outcome)
+        val secondOutput = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+        assertFalse(secondOutput.contains("com.google.code.gson:gson"), "gson must be excluded")
+        assertTrue(secondOutput.contains("org.slf4j:slf4j-api"), "slf4j must remain")
+    }
+
+    /**
+     * The previous `plugin should work with project isolation enabled` test is single-project,
+     * so isolated-projects is effectively a no-op there. This test exercises the real property:
+     * a multi-module build (`include(":a", ":b")`) where each subproject applies the plugin
+     * independently. With `isolated-projects=true` + CC, both tasks must run, neither must
+     * cause an isolation violation, and their outputs must NOT cross-contaminate.
+     */
+    @Test
+    fun `plugin works in multi-module build with project isolation enabled`() {
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "test-multi"
+            include(":moda", ":modb")
+            """.trimIndent()
+        )
+        File(projectDir, "gradle.properties").writeText(
+            """
+            org.gradle.unsafe.isolated-projects=true
+            org.gradle.configuration-cache=true
+            """.trimIndent()
+        )
+        File(projectDir, "build.gradle.kts").writeText("")
+        File(projectDir, "moda").mkdirs()
+        File(projectDir, "moda/build.gradle.kts").writeText(
+            """
+            plugins {
+                id("java-library")
+                id("com.mikepenz.aboutlibraries.plugin")
+            }
+            repositories { mavenCentral() }
+            dependencies {
+                implementation("com.google.code.gson:gson:2.11.0")
+            }
+            aboutLibraries { offlineMode = true }
+            """.trimIndent()
+        )
+        File(projectDir, "modb").mkdirs()
+        File(projectDir, "modb/build.gradle.kts").writeText(
+            """
+            plugins {
+                id("java-library")
+                id("com.mikepenz.aboutlibraries.plugin")
+            }
+            repositories { mavenCentral() }
+            dependencies {
+                implementation("org.slf4j:slf4j-api:2.0.16")
+            }
+            aboutLibraries { offlineMode = true }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val first = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(":moda:exportLibraryDefinitions", ":modb:exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertEquals(TaskOutcome.SUCCESS, first.task(":moda:exportLibraryDefinitions")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, first.task(":modb:exportLibraryDefinitions")?.outcome)
+        assertFalse(
+            first.output.contains("Configuration cache entry discarded"),
+            "Plugin must not cause isolated-projects violations across subprojects. Output: ${first.output}"
+        )
+
+        // Per-module output isolation: each module only sees its own deps.
+        val modaJson = File(projectDir, "moda/build/generated/aboutLibraries/aboutlibraries.json").readText()
+        val modbJson = File(projectDir, "modb/build/generated/aboutLibraries/aboutlibraries.json").readText()
+        assertTrue(modaJson.contains("com.google.code.gson:gson"), "moda must contain gson")
+        assertFalse(modaJson.contains("org.slf4j:slf4j-api"), "moda must NOT contain modb's slf4j")
+        assertTrue(modbJson.contains("org.slf4j:slf4j-api"), "modb must contain slf4j")
+        assertFalse(modbJson.contains("com.google.code.gson:gson"), "modb must NOT contain moda's gson")
+
+        // Second run must reuse CC and both tasks must be UP-TO-DATE.
+        @Suppress("WithPluginClasspathUsage")
+        val second = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(":moda:exportLibraryDefinitions", ":modb:exportLibraryDefinitions", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertTrue(
+            second.output.contains("Configuration cache entry reused") ||
+                second.output.contains("Reusing configuration cache"),
+            "CC should be reused on second run. Output: ${second.output}"
+        )
+        assertEquals(TaskOutcome.UP_TO_DATE, second.task(":moda:exportLibraryDefinitions")?.outcome)
+        assertEquals(TaskOutcome.UP_TO_DATE, second.task(":modb:exportLibraryDefinitions")?.outcome)
+    }
+
     @Test
     fun `configuration cache should work with multiple variants`() {
         setupProjectWithMultipleVariants(projectDir)

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/ConfigurationCacheTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/ConfigurationCacheTest.kt
@@ -314,7 +314,7 @@ class ConfigurationCacheTest {
             .withPluginClasspath()
             .build()
         assertFalse(
-            second.output.contains("Configuration cache entry reused"),
+            ccReused(second.output),
             "CC must NOT be reused after a dependency version change. Output: ${second.output}"
         )
         assertEquals(
@@ -381,7 +381,7 @@ class ConfigurationCacheTest {
             .withPluginClasspath()
             .build()
         assertFalse(
-            second.output.contains("Configuration cache entry reused"),
+            ccReused(second.output),
             "CC must invalidate when exclusionPatterns changes. Output: ${second.output}"
         )
         assertEquals(TaskOutcome.SUCCESS, second.task(":exportLibraryDefinitions")?.outcome)
@@ -500,6 +500,16 @@ class ConfigurationCacheTest {
 
         assertTrue(secondRun.output.contains("Configuration cache entry reused"))
     }
+
+    /**
+     * Returns true if [output] contains either of the configuration-cache reuse messages
+     * Gradle prints. Both forms are checked because the exact wording can vary across
+     * Gradle versions / TestKit modes — relying on only one is brittle for negative
+     * (`assertFalse`) assertions.
+     */
+    private fun ccReused(output: String): Boolean =
+        output.contains("Configuration cache entry reused") ||
+            output.contains("Reusing configuration cache")
 
     private fun setupProject(projectDir: File) {
         File(projectDir, "settings.gradle.kts").writeText(

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/FunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/FunctionalTest.kt
@@ -181,6 +181,84 @@ class FunctionalTest {
         )
     }
 
+    /**
+     * Verifies that the task is truly relocatable in the build cache: a cache entry produced
+     * in one project directory must be reused (FROM_CACHE) in a *different* project directory
+     * with byte-identical build scripts. This exercises `PathSensitivity.NONE` on the
+     * `pomFiles` input — any drift to a relocation-sensitive sensitivity would cause this
+     * test to miss the cache and fall back to SUCCESS.
+     */
+    @Test
+    fun `task is relocatable across project directories via build cache`() {
+        val sharedCache = File(projectDir, "shared-cache").apply { mkdirs() }
+        val dirA = File(projectDir, "dirA").apply { mkdirs() }
+        val dirB = File(projectDir, "dirB").apply { mkdirs() }
+
+        // The cache directory MUST match exactly between dirA and dirB so the same local cache
+        // is used for store and retrieve. We write its absolute path into each settings.gradle.kts.
+        val sharedCachePath = sharedCache.absolutePath.replace("\\", "\\\\")
+        fun setup(target: File) {
+            File(target, "settings.gradle.kts").writeText(
+                """
+                rootProject.name = "test-project"
+                buildCache {
+                    local {
+                        directory = file("$sharedCachePath")
+                        isEnabled = true
+                    }
+                }
+                """.trimIndent()
+            )
+            File(target, "build.gradle.kts").writeText(
+                """
+                plugins {
+                    id("java-library")
+                    id("com.mikepenz.aboutlibraries.plugin")
+                }
+                repositories { mavenCentral() }
+                dependencies {
+                    implementation("com.google.code.gson:gson:2.11.0")
+                    implementation("org.slf4j:slf4j-api:2.0.16")
+                }
+                aboutLibraries { offlineMode = true }
+                """.trimIndent()
+            )
+        }
+        setup(dirA)
+        setup(dirB)
+
+        // Populate the shared cache from dirA.
+        @Suppress("WithPluginClasspathUsage")
+        val firstRun = GradleRunner.create()
+            .withProjectDir(dirA)
+            .withArguments("exportLibraryDefinitions", "--build-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            firstRun.task(":exportLibraryDefinitions")?.outcome,
+            "First run in dirA must execute and store a cache entry"
+        )
+
+        // Run in a different directory pointing at the same cache. Outcome must be FROM_CACHE,
+        // strictly — any other outcome (SUCCESS) means the task is not actually relocatable.
+        @Suppress("WithPluginClasspathUsage")
+        val secondRun = GradleRunner.create()
+            .withProjectDir(dirB)
+            .withArguments("exportLibraryDefinitions", "--build-cache", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+        assertEquals(
+            TaskOutcome.FROM_CACHE,
+            secondRun.task(":exportLibraryDefinitions")?.outcome,
+            "Run in dirB against the shared cache must be FROM_CACHE (relocatable). Output: ${secondRun.output}"
+        )
+        assertTrue(
+            File(dirB, "build/generated/aboutLibraries/aboutlibraries.json").exists(),
+            "Output file must be restored from the cache into dirB"
+        )
+    }
+
     @Test
     fun `output should contain valid library structure with all required fields`() {
         setupDetailedProject(projectDir)


### PR DESCRIPTION
## Summary

Performance + correctness refactor of the AboutLibraries Gradle plugin's dependency-collection pipeline, plus four new tests covering high-value properties the existing suite missed. All work is on top of #1338 / commit f804b41.

### Plugin runtime (commit a53dabb4)

- **Single-pass dependency-graph walk per configuration.** Previously the graph was walked three times (once for the coordinate-keys `MapProperty<String, String>`, once inside `resolvePomFiles`, once again in `createLibraryPostProcessor` via pipe-encoded string parsing). Now: one walk produces both the per-config coordinate list and the union set used for POM resolution.
- **Typed coordinate map.** `MapProperty<String, String>` (pipe-encoded `g:a:v|g:a:v|…`) is replaced with `MapProperty<String, List<DependencyCoordinates>>`. `DependencyCoordinates` is already `java.io.Serializable`, so the configuration cache stores it directly. Kills the exec-time `split("|")/split(":")` round-trip.
- **Version-slot POM batching.** `resolvePomFiles` now partitions coordinates by `group:artifact` and fetches them in version slots: each detached configuration contains at most one version per `g:a`. The number of detached configurations is bounded by the maximum collision depth per `g:a` instead of the total coordinate count. The same slot batching is reused for parent-POM levels in Phase 2 (`while (parentsToFetch.isNotEmpty())`).
- **Configuration-cache hardening.**
  - The `extension` task field is gone — it's now a `@get:Internal` getter property with no backing field, so it is never serialized into the CC entry.
  - `resolvePomFiles` is evaluated eagerly inside `configure()` rather than via a `project.provider {}` closure that captured `Configuration` references.
  - Explicit `Property<Boolean>` / `Provider<Boolean>` types on `offlineMode`, `fetchRemoteLicense`, `fetchRemoteFunding` (drops `@Suppress("HasPlatformType")`).
- **`AboutLibrariesExportComplianceTask` input/output contract fix.**
  - `exportPath` is now `@OutputDirectory DirectoryProperty` (was `@Input Provider<Directory>`, so the task previously had **no declared outputs** and was never UP-TO-DATE).
  - Removes the bogus `@InputDirectory projectDirectory` that fingerprinted the entire project tree on every change.
  - Convention wiring moved into a `configure()` override.
- **Adds `@DisableCachingByDefault`** to the abstract base task and the compliance task so `validatePlugins` is green (pre-existing failure on develop).
- Sets `isTransitive = false` on the detached `@pom` configurations — small free win, skips graph construction.

### Tests (commit 0b4b6235)

The existing CC tests only proved the *reuse* path. These four tests cover the highest-value gaps a test-strategy review identified:

- **`configuration cache invalidates when dependency version changes`** — bumps a declared dep, asserts CC is NOT reused, the task re-runs, and the output reflects the new version (not the stale one).
- **`configuration cache invalidates when exclusionPatterns is added`** — asserts an extension change invalidates CC and the excluded library disappears from the output.
- **`plugin works in multi-module build with project isolation enabled`** — real `include(":moda", ":modb")` build with `isolated-projects=true` + CC. Asserts both subprojects execute, neither causes an isolation violation, per-module outputs do not cross-contaminate, and the second run reuses CC + UP-TO-DATE. The previous "project isolation" test was single-project and therefore vacuous.
- **`task is relocatable across project directories via build cache`** — writes byte-identical projects into two different directories pointing at the same shared local build cache, runs the task in `dirA`, then asserts the run in `dirB` is strictly `FROM_CACHE`. Exercises `PathSensitivity.NONE` on `pomFiles` — drift to a relocation-sensitive sensitivity would fail this test.

Total suite: **43/43 pass** (was 39).

## Test plan

- [x] `:plugin:test` — 43/43 pass
- [x] `:plugin:check` — passes (lint + tests)
- [x] `:plugin:validatePlugins` — passes (was failing on `develop`, fixed in this PR)
- [x] End-to-end against a real composite-build project (gson + guava + commons-io 3-level parent chain + ktor BOM + slf4j): output JSON contains all expected libraries with parent-POM-inherited metadata (developers, scm, organization)
- [x] CC store / reuse / invalidation verified end-to-end (changed gson version, observed re-run + new version in output)
- [x] Multi-module `isolated-projects=true` + CC end-to-end against the published-to-mavenLocal plugin: both modules run, zero violations from plugin runtime, per-module output isolation verified, second run reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)