### PR TITLE
feat(plugin): add includeLicenses build-time filter

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -104,6 +104,7 @@ abstract class AboutLibrariesExtension {
             it.allowedLicenses.convention(emptySet())
             it.allowedLicensesMap.convention(emptyMap())
             it.additionalLicenses.convention(emptySet())
+            it.includeLicenses.convention(emptySet())
             it.strictMode.convention(StrictMode.IGNORE)
         }
         android {
@@ -546,6 +547,26 @@ abstract class LicenseConfig @Inject constructor() {
      */
     @get:Optional
     abstract val additionalLicenses: SetProperty<String>
+
+    /**
+     * Defines the licenses to include in the output. When non-empty, only libraries
+     * with at least one license matching this set will appear in the generated JSON.
+     * When empty (default), all libraries are included.
+     *
+     * Matching is case-insensitive and supports SPDX IDs, license names, and license URLs.
+     *
+     * ```
+     * aboutLibraries {
+     *   license {
+     *      includeLicenses.addAll("Apache-2.0", "MIT")
+     *   }
+     * }
+     * ```
+     *
+     * This API accepts spdxId's, license names, or license URLs. A full list is available here: https://spdx.org/licenses/
+     */
+    @get:Optional
+    abstract val includeLicenses: SetProperty<String>
 
     /**
      * Enables an exceptional strictMode which will either log or crash the build in case non allowed licenses are detected.

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -107,6 +107,9 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val additionalLicenses = extension.license.additionalLicenses
 
     @Input
+    val includeLicenses = extension.license.includeLicenses
+
+    @Input
     @Optional
     val gitHubApiToken = extension.collect.gitHubApiToken
 
@@ -443,6 +446,7 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
             variantToDependencyData = variantToDependencyData,
             configFolder = realPath,
             exclusionPatterns = exclusionPatterns.get(),
+            includeLicenses = includeLicenses.get(),
             offlineMode = offlineMode.get(),
             fetchRemoteLicense = fetchRemoteLicense.get(),
             fetchRemoteFunding = fetchRemoteFunding.get(),

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryPostProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryPostProcessor.kt
@@ -15,11 +15,13 @@ import com.mikepenz.aboutlibraries.plugin.util.parser.LicenseReader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.util.Locale
 
 internal class LibraryPostProcessor(
     private val variantToDependencyData: Map<String, List<DependencyData>>,
     private val configFolder: File?,
     private val exclusionPatterns: Set<String>,
+    private val includeLicenses: Set<String>,
     private val offlineMode: Boolean,
     private val fetchRemoteLicense: Boolean,
     private val fetchRemoteFunding: Boolean,
@@ -52,6 +54,10 @@ internal class LibraryPostProcessor(
             }
         }
 
+        val lowercaseIncludeLicenses = if (includeLicenses.isNotEmpty()) {
+            includeLicenses.mapTo(HashSet(includeLicenses.size)) { it.lowercase(Locale.ENGLISH) }
+        } else emptySet()
+
         val variant = variant
         val dependencyDataForVariant = if (variant.isNullOrBlank()) {
             variantToDependencyData.flatMap { (_, dependencies) -> dependencies }.deduplicateDependencies() ?: emptySet()
@@ -76,6 +82,22 @@ internal class LibraryPostProcessor(
 
                     if (fetchRemoteLicense) {
                         api.fetchRemoteLicense(dependencyData.uniqueId, dependencyData.scm, licenses, mapLicensesToSpdx)
+                    }
+
+                    // License inclusion filter: skip libraries whose licenses don't match.
+                    if (lowercaseIncludeLicenses.isNotEmpty()) {
+                        val hasMatch = licenses.any { lic ->
+                            val id = lic.spdxId?.lowercase(Locale.ENGLISH)
+                            val name = lic.name.lowercase(Locale.ENGLISH)
+                            val url = lic.url?.lowercase(Locale.ENGLISH)
+                            lowercaseIncludeLicenses.contains(id) ||
+                                lowercaseIncludeLicenses.contains(name) ||
+                                (!url.isNullOrEmpty() && lowercaseIncludeLicenses.contains(url))
+                        }
+                        if (!hasMatch) {
+                            LOGGER.debug("Excluding library ${dependencyData.uniqueId} due to license inclusion filter")
+                            return@onEach
+                        }
                     }
 
                     val funding = mutableSetOf<Funding>()

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/OutputCorrectnessTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/OutputCorrectnessTest.kt
@@ -581,6 +581,89 @@ class OutputCorrectnessTest {
         )
     }
 
+    /**
+     * `includeLicenses` should only keep libraries whose license matches the inclusion set.
+     */
+    @Test
+    fun `includeLicenses filters libraries by license`() {
+        setupProject(
+            projectDir,
+            deps = """
+                implementation("com.google.code.gson:gson:2.11.0")
+                implementation("org.slf4j:slf4j-api:2.0.16")
+            """.trimIndent(),
+            extraConfig = """
+                license {
+                    includeLicenses.addAll("Apache-2.0")
+                }
+            """.trimIndent()
+        )
+
+        run("exportLibraryDefinitions")
+        val content = readOutput()
+        assertTrue(
+            content.contains("com.google.code.gson:gson"),
+            "gson (Apache-2.0) should be included"
+        )
+        assertFalse(
+            content.contains("org.slf4j:slf4j-api"),
+            "slf4j (MIT) should be excluded by license inclusion filter"
+        )
+    }
+
+    /**
+     * Empty `includeLicenses` (default) must include all libraries — no change in behavior.
+     */
+    @Test
+    fun `empty includeLicenses includes all libraries`() {
+        setupProject(
+            projectDir,
+            deps = """
+                implementation("com.google.code.gson:gson:2.11.0")
+                implementation("org.slf4j:slf4j-api:2.0.16")
+            """.trimIndent()
+        )
+
+        run("exportLibraryDefinitions")
+        val content = readOutput()
+        assertTrue(content.contains("com.google.code.gson:gson"), "gson should be present")
+        assertTrue(content.contains("org.slf4j:slf4j-api"), "slf4j should be present")
+    }
+
+    /**
+     * `includeLicenses` and `exclusionPatterns` should both apply independently.
+     */
+    @Test
+    fun `includeLicenses and exclusionPatterns work together`() {
+        setupProject(
+            projectDir,
+            deps = """
+                implementation("com.google.code.gson:gson:2.11.0")
+                implementation("org.slf4j:slf4j-api:2.0.16")
+            """.trimIndent(),
+            scriptHeader = """import java.util.regex.Pattern""",
+            extraConfig = """
+                library {
+                    exclusionPatterns.add(Pattern.compile("com\\.google\\.code\\.gson.*"))
+                }
+                license {
+                    includeLicenses.addAll("Apache-2.0", "MIT")
+                }
+            """.trimIndent()
+        )
+
+        run("exportLibraryDefinitions")
+        val content = readOutput()
+        assertFalse(
+            content.contains("com.google.code.gson:gson"),
+            "gson excluded by exclusionPatterns even though its license is in includeLicenses"
+        )
+        assertTrue(
+            content.contains("org.slf4j:slf4j-api"),
+            "slf4j should pass both filters"
+        )
+    }
+
     // ----- helpers -----
 
     private fun run(vararg args: String) =


### PR DESCRIPTION
## Summary

- Adds `includeLicenses` property to the `license { }` DSL block, allowing users to filter the generated JSON to only include libraries with specific licenses (by SPDX ID, name, or URL)
- When empty (default), all libraries are included — no behavior change for existing users
- Matching is case-insensitive and consistent with existing `allowedLicenses` validation logic

### Usage
```kotlin
aboutLibraries {
    license {
        includeLicenses.addAll("Apache-2.0", "MIT")
    }
}
```

Closes #1306

## Test plan

- [x] New test: `includeLicenses filters libraries by license` — verifies Apache-2.0 libs kept, MIT libs excluded
- [x] New test: `empty includeLicenses includes all libraries` — default behavior preserved
- [x] New test: `includeLicenses and exclusionPatterns work together` — both filters applied independently
- [x] Full plugin test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)