### PR TITLE
fix(build): remove os.arch=x86_64 workaround breaking Kotlin Native on arm64

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mikepenz
 POM_DEVELOPER_NAME=Mike Penz
 # Project-wide Gradle settings.
-org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M -Dos.arch=x86_64"
-systemProp.os.arch=x86_64
+org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
fix(build): remove os.arch=x86_64 workaround breaking Kotlin Native on arm64

The systemProp.os.arch=x86_64 and -Dos.arch=x86_64 JVM arg forced the Kotlin Native toolchain to download the x86_64 prebuilt, which cannot load on arm64 hosts (macOS arm64 CI runner, Linux aarch64). This caused the apiCheck task to fail with an incompatible architecture error.