### PR TITLE
feat(test): integrate DejaVu for Compose recomposition stability tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ ivy = "2.5.3"
 modelBuilder = "3.9.15"
 materialDrawer = "9.0.2"
 okhttp = "5.3.2"
+dejavu = "0.3.1"
 
 [plugins]
 navSafeArgs = { id = "androidx.navigation.safeargs", version.ref = "navigation" }
@@ -46,6 +47,7 @@ ivy-core = { module = "org.apache.ivy:ivy", version.ref = "ivy" }
 maven-modelBuilder = { module = "org.apache.maven:maven-model-builder", version.ref = "modelBuilder" }
 materialDrawer-core = { module = "com.mikepenz:materialdrawer", version.ref = "materialDrawer" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+dejavu = { module = "me.mmckenna.dejavu:dejavu", version.ref = "dejavu" }
 
 [bundles]
 androidx-lifecycle = [

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -30,6 +30,11 @@ dependencies {
     implementation(compose.components.resources)
     implementation(libs.androidx.activity.compose)
     debugImplementation(compose.uiTooling)
+
+    // Recomposition-stability tests
+    androidTestImplementation(libs.dejavu)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 
 compose.resources {

--- a/sample/android/src/androidTest/kotlin/com/mikepenz/aboutlibraries/ui/LibrariesListStabilityTest.kt
+++ b/sample/android/src/androidTest/kotlin/com/mikepenz/aboutlibraries/ui/LibrariesListStabilityTest.kt
@@ -1,0 +1,167 @@
+package com.mikepenz.aboutlibraries.ui
+
+import android.os.Looper
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mikepenz.aboutlibraries.entity.Developer
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
+import com.mikepenz.aboutlibraries.ui.compose.style.defaultVariantColors
+import com.mikepenz.aboutlibraries.ui.compose.style.librariesStyle
+import com.mikepenz.aboutlibraries.ui.compose.variant.Libraries
+import com.mikepenz.aboutlibraries.ui.compose.variant.LibrariesVariant
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+
+/**
+ * Verifies that the [Libraries] list composable is stable:
+ * - does not recompose when the same list reference is re-assigned
+ * - does recompose when the list content genuinely changes
+ */
+@RunWith(AndroidJUnit4::class)
+class LibrariesListStabilityTest {
+
+    /**
+     * DejaVu 0.3.1: Runtime.seedActiveActivity calls Choreographer.getInstance() on the
+     * instrumentation thread. AndroidJUnitRunner does not prepare a Looper on that thread,
+     * so the very first access to Choreographer throws. Preparing the Looper here is safe —
+     * the frame callback posted by seedActiveActivity will never fire (Looper is never pumped),
+     * but the synchronous ensureInspectionTag() call that precedes it is what actually seeds
+     * the inspection slots, so tracking works correctly.
+     */
+    @get:Rule(order = 0)
+    val looperRule: TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                if (Looper.myLooper() == null) Looper.prepare()
+                base.evaluate()
+            }
+        }
+    }
+
+    @get:Rule(order = 1)
+    val rule = createRecompositionTrackingRule()
+
+    private fun fakeLibrary(id: String, name: String = "Library $id") = Library(
+        uniqueId = "com.example:$id",
+        artifactVersion = "1.0.0",
+        name = name,
+        description = "Description for $name",
+        website = "https://example.com/$id",
+        developers = listOf(Developer(name = "Author", organisationUrl = null)),
+        organization = null,
+        scm = null,
+        licenses = setOf(
+            License(name = "Apache-2.0", url = null, spdxId = "Apache-2.0", licenseContent = null, hash = "apache")
+        ),
+    )
+
+    private val baseLibraries = listOf(
+        fakeLibrary("alpha"),
+        fakeLibrary("beta"),
+        fakeLibrary("gamma"),
+    )
+
+    // --- Traditional variant ---
+
+    @Test
+    fun librariesTraditional_stableWhenSameListReferenceReassigned() {
+        var libraries by mutableStateOf(baseLibraries)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            Libraries(
+                libraries = libraries,
+                style = style,
+                variant = LibrariesVariant.Traditional,
+                modifier = Modifier.fillMaxSize().testTag("list"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        // Re-assign the exact same reference — structural equality, no change.
+        libraries = baseLibraries
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("list").assertStable()
+    }
+
+    @Test
+    fun librariesTraditional_recomposesWhenListGrows() {
+        var libraries by mutableStateOf(baseLibraries)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            Libraries(
+                libraries = libraries,
+                style = style,
+                variant = LibrariesVariant.Traditional,
+                modifier = Modifier.fillMaxSize().testTag("list"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        libraries = baseLibraries + fakeLibrary("delta")
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("list").assertRecompositions(atLeast = 1)
+    }
+
+    // --- Refined variant ---
+
+    @Test
+    fun librariesRefined_stableWhenSameListReferenceReassigned() {
+        var libraries by mutableStateOf(baseLibraries)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            Libraries(
+                libraries = libraries,
+                style = style,
+                variant = LibrariesVariant.Refined,
+                modifier = Modifier.fillMaxSize().testTag("list"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        libraries = baseLibraries
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("list").assertStable()
+    }
+
+    @Test
+    fun librariesRefined_recomposesWhenListGrows() {
+        var libraries by mutableStateOf(baseLibraries)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            Libraries(
+                libraries = libraries,
+                style = style,
+                variant = LibrariesVariant.Refined,
+                modifier = Modifier.fillMaxSize().testTag("list"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        libraries = baseLibraries + fakeLibrary("delta")
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("list").assertRecompositions(atLeast = 1)
+    }
+}

--- a/sample/android/src/androidTest/kotlin/com/mikepenz/aboutlibraries/ui/LibraryRowStabilityTest.kt
+++ b/sample/android/src/androidTest/kotlin/com/mikepenz/aboutlibraries/ui/LibraryRowStabilityTest.kt
@@ -1,0 +1,232 @@
+package com.mikepenz.aboutlibraries.ui
+
+import android.os.Looper
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mikepenz.aboutlibraries.entity.Developer
+import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
+import com.mikepenz.aboutlibraries.ui.compose.style.defaultVariantColors
+import com.mikepenz.aboutlibraries.ui.compose.style.librariesStyle
+import com.mikepenz.aboutlibraries.ui.compose.variant.DefaultLibraryBadges
+import com.mikepenz.aboutlibraries.ui.compose.variant.LibrariesDensity
+import com.mikepenz.aboutlibraries.ui.compose.variant.refined.RefinedRow
+import com.mikepenz.aboutlibraries.ui.compose.variant.traditional.TraditionalRow
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import dejavu.resetRecompositionCounts
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that library row composables don't recompose unnecessarily when inputs are unchanged,
+ * and recompose exactly once when a relevant input changes.
+ */
+@RunWith(AndroidJUnit4::class)
+class LibraryRowStabilityTest {
+
+    /**
+     * DejaVu 0.3.1: Runtime.seedActiveActivity calls Choreographer.getInstance() on the
+     * instrumentation thread. AndroidJUnitRunner does not prepare a Looper on that thread,
+     * so the very first access to Choreographer throws. Preparing the Looper here is safe —
+     * the frame callback posted by seedActiveActivity will never fire (Looper is never pumped),
+     * but the synchronous ensureInspectionTag() call that precedes it is what actually seeds
+     * the inspection slots, so tracking works correctly.
+     */
+    @get:Rule(order = 0)
+    val looperRule: TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                if (Looper.myLooper() == null) Looper.prepare()
+                base.evaluate()
+            }
+        }
+    }
+
+    @get:Rule(order = 1)
+    val rule = createRecompositionTrackingRule()
+
+    // --- fixtures ---
+
+    private fun fakeLibrary(
+        id: String = "com.example:lib",
+        name: String = "Example Library",
+        version: String = "1.0.0",
+        author: String = "Example Author",
+        licenseId: String = "Apache-2.0",
+    ) = Library(
+        uniqueId = id,
+        artifactVersion = version,
+        name = name,
+        description = "A sample library for testing recomposition stability.",
+        website = "https://example.com",
+        developers = listOf(Developer(name = author, organisationUrl = null)),
+        organization = null,
+        scm = null,
+        licenses = setOf(
+            License(name = licenseId, url = null, spdxId = licenseId, licenseContent = null, hash = licenseId)
+        ),
+    )
+
+    // --- TraditionalRow ---
+
+    @Test
+    fun traditionalRow_stableWhenInputsUnchanged() {
+        val library = fakeLibrary()
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            TraditionalRow(
+                library = library,
+                expanded = false,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+        rule.mainClock.advanceTimeByFrame()
+
+        rule.onNodeWithTag("row").assertStable()
+    }
+
+    @Test
+    fun traditionalRow_recomposesExactlyOnceWhenExpandedChanges() {
+        val library = fakeLibrary()
+        var expanded by mutableStateOf(false)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            TraditionalRow(
+                library = library,
+                expanded = expanded,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        expanded = true
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("row").assertRecompositions(exactly = 1)
+    }
+
+    @Test
+    fun traditionalRow_stableWhenUnrelatedStateChanges() {
+        val library = fakeLibrary()
+        var unrelated by mutableIntStateOf(0)
+        rule.setContent {
+            @Suppress("UNUSED_EXPRESSION") unrelated
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            TraditionalRow(
+                library = library,
+                expanded = false,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        unrelated++
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("row").assertStable()
+    }
+
+    // --- RefinedRow ---
+
+    @Test
+    fun refinedRow_stableWhenInputsUnchanged() {
+        val library = fakeLibrary()
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            RefinedRow(
+                library = library,
+                expanded = false,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+        rule.mainClock.advanceTimeByFrame()
+
+        rule.onNodeWithTag("row").assertStable()
+    }
+
+    @Test
+    fun refinedRow_recomposesExactlyOnceWhenExpandedChanges() {
+        val library = fakeLibrary()
+        var expanded by mutableStateOf(false)
+        rule.setContent {
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            RefinedRow(
+                library = library,
+                expanded = expanded,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        expanded = true
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("row").assertRecompositions(exactly = 1)
+    }
+
+    @Test
+    fun refinedRow_stableWhenUnrelatedStateChanges() {
+        val library = fakeLibrary()
+        var unrelated by mutableIntStateOf(0)
+        rule.setContent {
+            @Suppress("UNUSED_EXPRESSION") unrelated
+            val style = LibraryDefaults.librariesStyle(colors = LibraryDefaults.defaultVariantColors())
+            RefinedRow(
+                library = library,
+                expanded = false,
+                onToggle = {},
+                density = LibrariesDensity.Cozy,
+                badges = DefaultLibraryBadges,
+                style = style,
+                modifier = Modifier.testTag("row"),
+            )
+        }
+        rule.waitForIdle()
+        rule.resetRecompositionCounts()
+
+        unrelated++
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("row").assertStable()
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `me.mmckenna.dejavu:dejavu:0.3.1` as an `androidTestImplementation` dependency alongside `androidx.compose.ui:ui-test-junit4`
- Introduces two instrumented test classes under `sample/android/src/androidTest`:
  - **`LibraryRowStabilityTest`** — verifies `TraditionalRow` and `RefinedRow` are stable (0 recompositions) when inputs are unchanged, recompose exactly once when `expanded` flips, and are stable when unrelated outer state changes
  - **`LibrariesListStabilityTest`** — verifies the Libraries lazy list (both variants) is stable when the same list reference is re-assigned, and recomposes (≥1) when the list actually grows
- Includes a lightweight `LooperRule` (order=0) that calls `Looper.prepare()` if the instrumentation thread has no Looper yet, fixing a `Choreographer.getInstance()` crash in DejaVu's `Runtime.seedActiveActivity`

## Test plan

- [ ] Run instrumented tests on a connected device/emulator: `./gradlew :sample:android:connectedDebugAndroidTest`
- [ ] Verify `LibraryRowStabilityTest` and `LibrariesListStabilityTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)