### PR TITLE
feat!: upgrade to Compose 1.11.0-rc01, drop x64 iOS/macOS targets

### DIFF
--- a/aboutlibraries-compose-m2/api/aboutlibraries-compose-m2.klib.api
+++ b/aboutlibraries-compose-m2/api/aboutlibraries-compose-m2.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/aboutlibraries-compose-m3/api/aboutlibraries-compose-m3.klib.api
+++ b/aboutlibraries-compose-m3/api/aboutlibraries-compose-m3.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/aboutlibraries-compose/api/aboutlibraries-compose.klib.api
+++ b/aboutlibraries-compose/api/aboutlibraries-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/aboutlibraries-core/api/aboutlibraries-core.klib.api
+++ b/aboutlibraries-core/api/aboutlibraries-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
     }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach { iosTarget ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.14.4")
+            from("com.mikepenz:version-catalog:0.16.0-rc03")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bump `com.mikepenz:version-catalog` to `0.16.0-rc03` (brings Compose Multiplatform 1.11.0-rc01)
- Drop `iosX64()` from `sample/shared` — Compose 1.11 no longer publishes `iosX64`/`macosX64` artifacts for `components-resources`

## Breaking
- Removes support for `iosX64` and `macosX64` targets

## Test plan
- [ ] `./gradlew build`
- [ ] `./gradlew :sample:desktop:run`
- [ ] `./gradlew :sample:android:assembleDebug`
- [ ] `./gradlew apiCheck`