### PR TITLE
Make AGP 8.13 the minimum required version for v15 of the aboutlibraries plugin

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,7 @@
     - Remove `LibsBuilder`, `LibsActivity`, `LibsFragment`, and `LibsConfiguration` usages from your code.
     - See the [README](README.md) for the Compose UI setup and usage.
 - **Breaking Change**: Upgrade to Compose 1.11.x which drops support for `macosX64` and `iosX64` targets. If you were using these targets, you will need to migrate to the new `macosArm64` and `iosArm64` targets respectively.
+- **Breaking Change**: The Android Gradle Plugin (AGP) version 8.13.0 or greater is now required when applying the `.android` plugin.
 
 #### v14.0.0
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This library collects dependency details, including licenses at compile time, an
 
 ## Latest releases 🛠
 
-- Compose 1.11.x | New UI | [v15.0.0-a02](https://github.com/mikepenz/AboutLibraries/tree/15.0.0-a02)
+- Compose 1.11.x | New UI | AGP 8.13 | [v15.0.0-a02](https://github.com/mikepenz/AboutLibraries/tree/15.0.0-a02)
 - Compose 1.10.x | AGP 9 | [v14.1.0](https://github.com/mikepenz/AboutLibraries/tree/14.1.0)
 - Compose 1.10.x | [v13.2.1](https://github.com/mikepenz/AboutLibraries/tree/13.2.1)
 

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroid.kt
@@ -14,12 +14,7 @@ class AboutLibrariesPluginAndroid : Plugin<Project> {
             return
         }
 
-        try {
-            Class.forName("com.android.build.api.variant.AndroidComponentsExtension")
-        } catch (t: Throwable) {
-            project.logger.error("Android Gradle Plugin 7.0.0 or greater is required to apply this plugin.")
-            return
-        }
+
 
         // create the extension for the about libraries plugin
         val extension = project.extensions.findByType(AboutLibrariesExtension::class.java) ?: project.extensions.create("aboutLibraries", AboutLibrariesExtension::class.java)

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.aboutlibraries.plugin
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.AndroidPluginVersion
 import com.mikepenz.aboutlibraries.plugin.util.configure
 import org.gradle.api.Project
 
@@ -13,6 +14,10 @@ internal fun configureAndroidTasks(
         AboutLibrariesPlugin.LOGGER.debug("Registering Android task for Application")
 
         project.extensions.configure(AndroidComponentsExtension::class.java) {
+            if (it.pluginVersion < AndroidPluginVersion(8, 13, 0)) {
+                project.logger.error("Android Gradle Plugin 8.13.0 or greater is required to apply this plugin. (Found: ${it.pluginVersion})")
+                return@configure
+            }
             it.onVariants { variant ->
                 block(project, extension, variant)
             }
@@ -21,6 +26,10 @@ internal fun configureAndroidTasks(
     project.pluginManager.withPlugin("com.android.library") {
         AboutLibrariesPlugin.LOGGER.debug("Registering Android task for Library")
         project.extensions.configure(AndroidComponentsExtension::class.java) {
+            if (it.pluginVersion < AndroidPluginVersion(8, 13, 0)) {
+                project.logger.error("Android Gradle Plugin 8.13.0 or greater is required to apply this plugin. (Found: ${it.pluginVersion})")
+                return@configure
+            }
             it.onVariants { variant ->
                 block(project, extension, variant)
             }
@@ -29,6 +38,10 @@ internal fun configureAndroidTasks(
     project.pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
         AboutLibrariesPlugin.LOGGER.debug("Registering Android task for Kotlin Multiplatform Library")
         project.extensions.configure(AndroidComponentsExtension::class.java) {
+            if (it.pluginVersion < AndroidPluginVersion(8, 13, 0)) {
+                project.logger.error("Android Gradle Plugin 8.13.0 or greater is required to apply this plugin. (Found: ${it.pluginVersion})")
+                return@configure
+            }
             it.onVariants { variant ->
                 block(project, extension, variant)
             }


### PR DESCRIPTION
Closes #1371