### PR TITLE
Add `overscroll` effect parameter

### DIFF
--- a/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
+++ b/aboutlibraries-compose-m2/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/SharedLibraries.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.aboutlibraries.ui.compose
 
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.indication
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
@@ -82,6 +84,7 @@ fun LibrariesContainer(
     footer: (LazyListScope.() -> Unit)? = null,
     licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, mod -> LicenseDialogBody(library = library, colors = colors, modifier = mod) },
     licenseDialogConfirmText: String = "OK",
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     var openDialog by remember { mutableStateOf<Library?>(null) }
 
@@ -91,6 +94,7 @@ fun LibrariesContainer(
         onDialogLibraryChange = { openDialog = it },
         modifier = modifier,
         lazyListState = lazyListState,
+        overscrollEffect = overscrollEffect,
         contentPadding = contentPadding,
         badges = badges,
         actionLabels = actionLabels,
@@ -140,6 +144,7 @@ fun LibrariesContainer(
     footer: (LazyListScope.() -> Unit)? = null,
     licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, mod -> LicenseDialogBody(library = library, colors = colors, modifier = mod) },
     licenseDialogConfirmText: String = "OK",
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     val libs = libraries?.libraries.orEmpty()
 
@@ -163,6 +168,7 @@ fun LibrariesContainer(
         actionLabels = actionLabels,
         contentPadding = contentPadding,
         state = lazyListState,
+        overscrollEffect = overscrollEffect,
         header = header,
         divider = divider,
         footer = footer,

--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/SharedLibraries.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.aboutlibraries.ui.compose.m3
 
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.indication
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
@@ -87,6 +89,7 @@ fun LibrariesContainer(
     footer: (LazyListScope.() -> Unit)? = null,
     licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, mod -> LicenseDialogBody(library = library, colors = colors, modifier = mod) },
     licenseDialogConfirmText: String = "OK",
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     var openDialog by remember { mutableStateOf<Library?>(null) }
     var openSheet by remember { mutableStateOf<Library?>(null) }
@@ -99,6 +102,7 @@ fun LibrariesContainer(
         onSheetLibraryChange = { openSheet = it },
         modifier = modifier,
         lazyListState = lazyListState,
+        overscrollEffect = overscrollEffect,
         contentPadding = contentPadding,
         badges = badges,
         actionLabels = actionLabels,
@@ -149,6 +153,7 @@ fun LibrariesContainer(
     footer: (LazyListScope.() -> Unit)? = null,
     licenseDialogBody: (@Composable (Library, Modifier) -> Unit)? = { library, mod -> LicenseDialogBody(library = library, colors = colors, modifier = mod) },
     licenseDialogConfirmText: String = "OK",
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     val libs = libraries?.libraries.orEmpty()
 
@@ -201,6 +206,7 @@ fun LibrariesContainer(
         actionLabels = actionLabels,
         contentPadding = contentPadding,
         state = lazyListState,
+        overscrollEffect = overscrollEffect,
         header = header,
         divider = divider,
         footer = footer,

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/Libraries.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/Libraries.kt
@@ -1,5 +1,6 @@
 package com.mikepenz.aboutlibraries.ui.compose.variant
 
+import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -7,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -49,6 +51,7 @@ fun Libraries(
     onSheetRequest: ((Library) -> Unit)? = null,
     onActionClick: ((Library, LibraryActionKind) -> Boolean)? = null,
     onDialogRequest: ((Library) -> Unit)? = null,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     val row: @Composable LazyItemScope.(Library, Boolean, () -> Unit) -> Unit =
         remember(variant, density, badges, style) {
@@ -111,6 +114,7 @@ fun Libraries(
         row = row,
         modifier = modifier,
         state = state,
+        overscrollEffect = overscrollEffect,
         contentPadding = contentPadding,
         itemSpacing = itemSpacing,
         detailMode = detailMode,

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/LibraryListScaffold.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/LibraryListScaffold.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,6 +51,7 @@ fun LibraryListScaffold(
     header: (LazyListScope.() -> Unit)? = null,
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     var expandedId by rememberSaveable { mutableStateOf<String?>(null) }
     LibraryListScaffold(
@@ -58,6 +61,7 @@ fun LibraryListScaffold(
         row = row,
         modifier = modifier,
         state = state,
+        overscrollEffect = overscrollEffect,
         contentPadding = contentPadding,
         itemSpacing = itemSpacing,
         detailMode = detailMode,
@@ -93,6 +97,7 @@ fun LibraryListScaffold(
     header: (LazyListScope.() -> Unit)? = null,
     divider: (@Composable LazyItemScope.() -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
 ) {
     val verticalArrangement = remember(itemSpacing) {
         if (itemSpacing.value > 0f) Arrangement.spacedBy(itemSpacing) else Arrangement.Top
@@ -102,6 +107,7 @@ fun LibraryListScaffold(
         state = state,
         contentPadding = contentPadding,
         verticalArrangement = verticalArrangement,
+        overscrollEffect = overscrollEffect,
     ) {
         header?.invoke(this)
         itemsIndexed(

--- a/sample/shared/src/commonMain/kotlin/com/mikepenz/aboutlibraries/sample/App.kt
+++ b/sample/shared/src/commonMain/kotlin/com/mikepenz/aboutlibraries/sample/App.kt
@@ -315,7 +315,6 @@ fun App(libs: Libs?) {
                     val contrastLevel = if (settings.highContrast) ContrastLevel.High else ContrastLevel.Normal
                     if (settings.useMaterial3) {
                         M3LibrariesContainer(
-                            overscrollEffect = null,
                             libraries = libs?.let { Libs(filteredLibs, it.licenses) },
                             modifier = Modifier.weight(1f).fillMaxWidth(),
                             badges = settings.badges,

--- a/sample/shared/src/commonMain/kotlin/com/mikepenz/aboutlibraries/sample/App.kt
+++ b/sample/shared/src/commonMain/kotlin/com/mikepenz/aboutlibraries/sample/App.kt
@@ -315,6 +315,7 @@ fun App(libs: Libs?) {
                     val contrastLevel = if (settings.highContrast) ContrastLevel.High else ContrastLevel.Normal
                     if (settings.useMaterial3) {
                         M3LibrariesContainer(
+                            overscrollEffect = null,
                             libraries = libs?.let { Libs(filteredLibs, it.licenses) },
                             modifier = Modifier.weight(1f).fillMaxWidth(),
                             badges = settings.badges,


### PR DESCRIPTION
## Summary

Adds an `overscrollEffect` option to the Compose libraries list so callers can control the `LazyColumn` overscroll behavior.

## Issue

`LibrariesScaffold`/the shared list scaffold always used the default `LazyColumn` overscroll behavior internally. Consumers had no way to disable overscroll or provide a custom `OverscrollEffect`, which leads to the stretchy overscroll effect 👇🏽

https://github.com/user-attachments/assets/05da0192-9e66-482f-9d5a-2d4239e0ed60



## Fix

- Added `overscrollEffect: OverscrollEffect? = rememberOverscrollEffect()` to the shared list APIs.
- Passed the value through M2/M3 `LibrariesContainer` and `Libraries` into `LibraryListScaffold`.
- Applied `overscrollEffect = overscrollEffect` directly to the backing `LazyColumn`.

Existing behavior remains unchanged by default. Callers can pass `null` to disable overscroll or pass a custom remembered effect 

When overscroll is set to `null` as a parameter when using `M3LibrariesContainer()` in the test app👇🏽

https://github.com/user-attachments/assets/f8b0c4e9-ba39-47b8-9246-a6a0340ed235

