### PR TITLE
chore(deps): update version-catalog to 0.17.3

### DIFF
--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
             from(files("../gradle/libs.versions.toml"))
         }
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.17.1")
+            from("com.mikepenz:version-catalog:0.17.3")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.17.1")
+            from("com.mikepenz:version-catalog:0.17.3")
         }
     }
 }


### PR DESCRIPTION
Bumps the shared `com.mikepenz:version-catalog` convention plugin pins:

- `settings.gradle.kts`: `0.17.0` -> `0.17.3`
- `plugin-build/settings.gradle.kts`: `0.16.0` -> `0.17.3`

## Transitive version changes

### via com.mikepenz:version-catalog 0.17.0 -> 0.17.3 (main)
- compose 1.11.2 -> 1.11.3
- kotlinxCollectionsImmutable 0.4.0 -> 0.5.0
- lintGradle 1.0.0-rc01 -> 1.0.0
- aboutLibraries 15.0.0-b03 -> 15.0.0-rc01
- composeHotReload 1.2.0-alpha01 -> 1.2.0-alpha02
- stabilityAnalyzer 0.9.0 -> 0.10.0
- kotlinx-coroutines-test (added)

### via com.mikepenz:version-catalog 0.16.0 -> 0.17.3 (plugin-build)
- compileSdk 36 -> 37
- targetSdk 36 -> 37
- compose 1.11.1 -> 1.11.3
- compose-wear 1.6.1 -> 1.6.2
- compose-multiplatform 1.11.0 -> 1.11.1
- kotlin 2.3.21 -> 2.4.0
- kotlinxCollectionsImmutable 0.4.0 -> 0.5.0
- screenshot 0.0.1-alpha14 -> 0.0.1-alpha15
- lintGradle 1.0.0-beta01 -> 1.0.0
- aboutLibraries 14.2.0 -> 15.0.0-rc01
- composeHotReload 1.1.1 -> 1.2.0-alpha02
- stabilityAnalyzer 0.7.5 -> 0.10.0
- kotlinx-coroutines-test (added)

## Verification
- `./gradlew help` (main) -> BUILD SUCCESSFUL (settings eval + catalog import + all subproject configuration)
- `./gradlew tasks` (main) -> BUILD SUCCESSFUL
- `cd plugin-build && ./gradlew help` -> BUILD SUCCESSFUL
