### PR TITLE
fix(plugin): configure outputFile for android exportLibraryDefinitions task

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesPluginAndroidExtension.kt
@@ -70,6 +70,7 @@ private fun configureAndroidTasks(project: Project, extension: AboutLibrariesExt
     // task to generate libraries, and their license into the build folder (not hooked to the build task)
     project.tasks.configure("exportLibraryDefinitions${variantName}", AboutLibrariesTask::class.java) {
         it.variant.set(variant.name)
+        it.configureOutputFile()
         it.configure()
     }
 

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/KmpAndroidFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/KmpAndroidFunctionalTest.kt
@@ -41,6 +41,31 @@ class KmpAndroidFunctionalTest {
     }
 
     @Test
+    fun `android-specific exportLibraryDefinitions task runs without requiring outputFile`() {
+        setupKmpAndroidProject(projectDir)
+
+        // discover the android-specific task name (e.g. exportLibraryDefinitionsAndroid)
+        val tasksResult = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("tasks", "--all", "--stacktrace")
+            .build()
+        val taskName = Regex("exportLibraryDefinitions(Android\\w*|Debug|Release)")
+            .find(tasksResult.output)?.value
+            ?: error("Expected an android-specific exportLibraryDefinitions* task. Tasks output:\n${tasksResult.output}")
+
+        // regression: without configureOutputFile() this fails with "outputFile Value not set"
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(taskName, "--stacktrace")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":$taskName")?.outcome)
+
+        val outputFile = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json")
+        assertTrue(outputFile.exists(), "Output file should be created by :$taskName")
+    }
+
+    @Test
     fun `plugin resolves android-target dependencies in KMP module`() {
         setupKmpAndroidProject(projectDir)
 


### PR DESCRIPTION
## Problem

Closes #1403.

After upgrading to 15.0.0, running `exportLibraryDefinitions<Variant>` on an Android module fails:

```
A problem was found with the configuration of task ':app:exportLibraryDefinitionsFullDebug' (type 'AboutLibrariesTask').
Value not set
  Type 'com.mikepenz.aboutlibraries.plugin.AboutLibrariesTask' property 'outputFile' doesn't have a configured value
```

## Root cause

`AboutLibrariesTask.outputFile` is a non-optional `@get:OutputFile` and only receives a value via `configureOutputFile()`.

During the 15.0.0 migration to the new AGP variant API (commit `56622d8a`), the call to `configureOutputFile()` was dropped from the android-specific `exportLibraryDefinitions${variant}` registration. The global and KMP variants still call it, which is why only the android task regressed (and why switching to `prepareLibraryDefinitions<Variant>` works as a workaround).

## Fix

Restore the `it.configureOutputFile()` call for the android `exportLibraryDefinitions${variant}` task in `AboutLibrariesPluginAndroidExtension.kt`. With no argument it falls back to `build/generated/aboutLibraries/aboutlibraries.json`, matching the global/KMP behavior.

## Test

Adds a functional test in `KmpAndroidFunctionalTest` that executes the android-specific `exportLibraryDefinitions` task and asserts success + output file creation. Fails without the fix (task validation error), passes with it.