### PR TITLE
fix(compose-m3): fix spurious horizontal padding in license bottom sheet

### DIFF
--- a/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/sheet/LibraryDetailSheet.kt
+++ b/aboutlibraries-compose-m3/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/m3/sheet/LibraryDetailSheet.kt
@@ -44,14 +44,20 @@ import com.mikepenz.aboutlibraries.ui.compose.variant.LibrarySheetDetail
  * Provides the Material `ModalBottomSheet` shell, drag handle, and surface colors. All inner
  * layout (title, meta, description, license body, action affordances) lives in core.
  *
- * The sheet is fullscreen edge-to-edge by default ([contentWindowInsets] is empty): the surface
- * fills behind the status bar / display cutout at the top and behind the gesture navigation bar at
- * the bottom when fully expanded. Insets are instead applied to the elements that need them — the
- * [DefaultDragHandle] takes the top status-bar + cutout inset (so it clears the camera cutout), and
- * the inner [LibrarySheetDetail] takes the bottom + horizontal navigation-bar / cutout inset (so
- * text clears the indicator, side nav bar, and notch in landscape / reverse-portrait). Handle and
- * content cover disjoint sides, and all pad via `windowInsetsPadding`, whose inset consumption means
- * overriding [contentWindowInsets] is deduplicated rather than double-padded.
+ * Insets are split between three owners so each side is handled exactly once:
+ *  - [DefaultDragHandle] owns the **top** (status-bar + display-cutout top) so the handle clears
+ *    the camera notch when the sheet is fully expanded.
+ *  - The sheet's `modifier` owns the **horizontal** sides via `windowInsetsPadding` (systemBars +
+ *    displayCutout horizontal). Applying insets here constrains the sheet surface width itself
+ *    rather than padding content inside, so text fills the available width naturally and the sheet
+ *    does not extend behind side navigation bars or side cutouts. Because `windowInsetsPadding`
+ *    marks insets as consumed, [LibrarySheetDetail] inside sees the horizontal values as zero and
+ *    never double-pads.
+ *  - [LibrarySheetDetail] owns the **bottom** (navigation bar + bottom display-cutout) for
+ *    edge-to-edge scrolling.
+ *
+ * All three use `windowInsetsPadding`, whose consumption propagation means [contentWindowInsets]
+ * overrides are automatically deduplicated — inner composables never double-pad.
  *
  * The top corners animate from the style's `sheetShape` rounding to square as the sheet is dragged
  * to the top edge (fully expanded, covering the screen), and back when collapsed. A sheet shorter
@@ -73,7 +79,10 @@ fun LibraryDetailSheet(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        modifier = modifier,
+        modifier = modifier.windowInsetsPadding(
+            WindowInsets.systemBars.union(WindowInsets.displayCutout)
+                .only(WindowInsetsSides.Horizontal),
+        ),
         sheetState = sheetState,
         shape = rememberExpandingSheetShape(style.shapes.sheetShape, sheetState),
         containerColor = style.colors.sheetSurface.takeOrElse { MaterialTheme.colorScheme.surfaceContainerHigh },

--- a/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/LibraryDetailBody.kt
+++ b/aboutlibraries-compose/src/commonMain/kotlin/com/mikepenz/aboutlibraries/ui/compose/variant/LibraryDetailBody.kt
@@ -71,12 +71,11 @@ fun LibraryInlineDetail(
  * Sheet body rendered inside a modal bottom sheet — title, meta line, description, license body
  * and action bar. The wrapping [LibraryDetailSheet] adapter (M3) supplies the sheet shell.
  *
- * Consumes the bottom + horizontal system-bar and display-cutout insets on its own content so the
- * sheet surface can render edge-to-edge (behind the gesture indicator, side nav bar, and notch)
- * while text stays clear of them. The top inset is intentionally excluded — the wrapping sheet's
- * drag handle owns it — so handle and content cover disjoint sides with no double padding. This
- * holds across portrait, landscape, and reverse-portrait, where the bars/cutout move between edges.
- * The inset scrolls with the content, so the last item can be scrolled fully clear of the bars.
+ * Consumes only the **bottom** system-bar and display-cutout insets so text stays clear of the
+ * gesture indicator and (rare) bottom-edge notch. Horizontal insets are intentionally excluded:
+ * when rendered inside [LibraryDetailSheet] they are already consumed by the sheet's own modifier
+ * and resolve to zero here. The top inset is intentionally excluded — the wrapping sheet's drag
+ * handle owns it.
  */
 @Composable
 fun LibrarySheetDetail(
@@ -99,7 +98,7 @@ fun LibrarySheetDetail(
             modifier = Modifier.fillMaxWidth().then(scrollModifier)
                 .windowInsetsPadding(
                     WindowInsets.systemBars.union(WindowInsets.displayCutout)
-                        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                        .only(WindowInsetsSides.Bottom),
                 )
                 .padding(contentPadding),
             verticalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
## Summary

Fixes #1413.

Devices with a top-left punch-hole camera can report a non-zero `displayCutout` left safe-inset even in portrait, because the cutout bounding rect may touch the left edge. The previous approach applied `systemBars ∪ displayCutout` horizontal via `windowInsetsPadding` inside `LibrarySheetDetail`, producing spurious left padding in the sheet content even when the cutout does not overlap the sheet.

**Changes:**
- `LibraryDetailSheet` now applies `windowInsetsPadding(systemBars ∪ displayCutout, Horizontal)` on the `ModalBottomSheet` **modifier** — this constrains the sheet surface width itself rather than padding content inside it. Compose's inset consumption chain propagates inward so `LibrarySheetDetail` never double-pads.
- `LibrarySheetDetail` now only applies **bottom** insets (`systemBars ∪ displayCutout, Bottom`) for edge-to-edge scroll clearance.
- `DefaultDragHandle` continues to own the **top** inset (status-bar + cutout top) — unchanged.

## Test plan

- [ ] Verify on a device with a top-left punch-hole camera in portrait — sheet content should no longer have spurious left padding
- [ ] Verify in landscape with a side navigation bar — sheet correctly does not extend behind the nav bar
- [ ] Run screenshot tests: `./gradlew :sample:android:verifyPaparazziDebug`