### PR TITLE
fix(build): stop leaking compose-stability-runtime into consumers

### DIFF
--- a/aboutlibraries-compose-m2/build.gradle.kts
+++ b/aboutlibraries-compose-m2/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.mikepenz.convention.kotlin-multiplatform")
     id("com.mikepenz.convention.compose")
     id("com.mikepenz.convention.publishing")
-    alias(baseLibs.plugins.stabilityAnalyzer)
 }
 
 composeCompiler {

--- a/aboutlibraries-compose-m3/build.gradle.kts
+++ b/aboutlibraries-compose-m3/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.mikepenz.convention.kotlin-multiplatform")
     id("com.mikepenz.convention.compose")
     id("com.mikepenz.convention.publishing")
-    alias(baseLibs.plugins.stabilityAnalyzer)
 }
 
 composeCompiler {

--- a/aboutlibraries-compose-wear-m3/build.gradle.kts
+++ b/aboutlibraries-compose-wear-m3/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.mikepenz.convention.android-library")
     id("com.mikepenz.convention.compose")
     id("com.mikepenz.convention.publishing")
-    alias(baseLibs.plugins.stabilityAnalyzer)
 }
 
 android {

--- a/aboutlibraries-compose/build.gradle.kts
+++ b/aboutlibraries-compose/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.mikepenz.convention.kotlin-multiplatform")
     id("com.mikepenz.convention.compose")
     id("com.mikepenz.convention.publishing")
-    alias(baseLibs.plugins.stabilityAnalyzer)
 }
 
 composeCompiler {


### PR DESCRIPTION
Fixes #1424

## Problem

Every published Compose module drags `com.github.skydoves:compose-stability-runtime` onto consumers' runtime classpath:

```xml
<dependency>
  <groupId>com.github.skydoves</groupId>
  <artifactId>compose-stability-runtime-android</artifactId>
  <scope>runtime</scope>
</dependency>
```

## Cause

`alias(baseLibs.plugins.stabilityAnalyzer)` was applied to the four published modules. The plugin unconditionally adds `compose-stability-runtime` as an `implementation` dependency → lands in `runtimeElements` → POM `runtime` scope. It's not in `apiElements`, which matches the reporter's "runtimeClassPath" wording.

Not a convention-repo issue — `com.mikepenz:version-catalog` only declares the coordinates, no convention plugin applies it.

## Why it's safe to drop

The analyzer is a dev tool (recomposition tracing). In this repo it was applied but never used:

- No `composeStabilityAnalyzer {}` block anywhere.
- No `@StableForAnalysis` / `@IgnoreStabilityReport` / `RecompositionTracker` usage in any `.kt` file.
- 0 of 10 classes in `aboutlibraries-compose-m3-jvm-15.0.3.jar` reference `com/skydoves/compose/stability`; same for `aboutlibraries-compose-jvm`.

Pure dead weight for consumers.

The `composeCompiler { stabilityConfigurationFiles … }` blocks are JetBrains Compose compiler config, independent of skydoves, and are left untouched.

## Change

Removed the plugin from `aboutlibraries-compose`, `-m2`, `-m3`, `-wear-m3`. Kept on `app`, where tracing is genuinely useful.

## Affected versions

Present since `14.0.0-a01` (runtime `0.7.1`); `15.0.3` shipped `0.10.0`. Clean through `13.2.1`.

## Verification

- `:aboutlibraries-compose:dependencies --configuration jvmRuntimeClasspath` and the same for `-m3` — no skydoves.
- Positive control: `:app:dependencies --configuration debugRuntimeClasspath` still resolves `com.github.skydoves:compose-stability-runtime:0.10.0` as its own top-level dep, no longer transitively.
- `generateMetadataFileForJvmPublication` + `generatePomFileForJvmPublication` for `-m3` — generated `.module` and `.pom` contain no skydoves reference.
- All four modules compile.