### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,11 @@
 ### Upgrade Notes
 
+#### v15.1.0
+
+- **Breaking Change (Gradle Plugin)**: The Gradle plugin now targets Java 17 (previously Java 11), following AGP 9.3.1 which raised its own JVM target to 17.
+    - Your Gradle build must run on JDK 17 or newer. Gradle 9 already requires JDK 17+, so no change is needed if you are on Gradle 9.
+    - On Gradle 8.x with a JDK 11 daemon you will see `Unsupported class file major version` or a variant resolution failure — switch the daemon to JDK 17+ via `org.gradle.java.home` or your toolchain setup.
+
 #### v15.0.0
 
 - **Breaking Change**: The legacy View-based UI module (`com.mikepenz:aboutlibraries`) has been removed.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinxSerialization = "1.11.0"
 # androidx
 activity = "1.13.0"
 cardview = "1.0.0"
-constraintLayout = "2.2.1"
+constraintLayout = "2.2.2"
 core = "1.19.0"
 lifecycle = { require = "2.11.0" }
 navigation = "2.9.8"

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -44,12 +44,12 @@ gradlePlugin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
     compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_2_1)
         languageVersion.set(KotlinVersion.KOTLIN_2_1)

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
             from(files("../gradle/libs.versions.toml"))
         }
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.18.0")
+            from("com.mikepenz:version-catalog:0.19.0")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.18.0")
+            from("com.mikepenz:version-catalog:0.19.0")
         }
     }
 }


### PR DESCRIPTION
## Changes

- `androidx.constraintlayout:constraintlayout` 2.2.1 -> 2.2.2

via `com.mikepenz:version-catalog` 0.18.0 -> 0.19.0:
- `agp` 9.2.1 -> 9.3.1
- `kotlin` 2.4.0 -> 2.4.10
- `aboutLibraries` 15.0.3 -> 15.0.4
- `composeHotReload` 1.2.0-rc01 -> 1.3.0-alpha01
- `stabilityAnalyzer` 0.10.0 -> 0.12.0

## Java 17 toolchain for the Gradle plugin

AGP 9.3.1 raises its published `org.gradle.jvm.version` from 11 to 17, so `plugin-build/plugin` no longer resolves with a Java 11 toolchain:

```
> No matching variant of com.android.tools.build:gradle:9.3.1 was found.
   - Incompatible because this component declares a component, compatible with Java 17
     and the consumer needed a component, compatible with Java 11
```

Bumped `sourceCompatibility`/`targetCompatibility`/`jvmToolchain` to 17. Gradle 9 already requires JDK 17+ to run, so the supported runtime is unchanged.

## Verification

- `./gradlew build -x lint` — passing
- `./gradlew apiCheck` — passing
- `cd plugin-build && ./gradlew test` — passing