### PR TITLE
feat(plugin): add `mergePlatformArtifacts` to report KMP artifacts under their root coordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ aboutLibraries {
         duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
         // Configure the duplication rule, to match "duplicates" with
         duplicationRule = com.mikepenz.aboutlibraries.plugin.DuplicateRule.SIMPLE
+        // Report the per-platform artifacts of a Kotlin Multiplatform publication under the declared
+        // root coordinate (`androidx.collection:collection`, not `androidx.collection:collection-jvm`).
+        // Unrelated to Android build variants — see `filterVariants` for those.
+        mergePlatformArtifacts = true
     }
 }
 ```

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -88,6 +88,7 @@ abstract class AboutLibrariesExtension {
             it.exclusionPatterns.convention(emptySet<Pattern>())
             it.duplicationMode.convention(DuplicateMode.MERGE)
             it.duplicationRule.convention(DuplicateRule.EXACT)
+            it.mergePlatformArtifacts.convention(false)
         }
         license {
             it.mapLicensesToSpdx.convention(true)
@@ -451,6 +452,47 @@ abstract class LibraryConfig @Inject constructor() {
      */
     @get:Optional
     abstract val duplicationRule: Property<DuplicateRule>
+
+    /**
+     * Reports the per-platform artifacts of a Kotlin Multiplatform publication under the single
+     * root coordinate they were resolved through, instead of under the resolved artifact's own id.
+     *
+     * A dependency declared as `com.mikepenz:aboutlibraries-compose-core` resolves to
+     * `com.mikepenz:aboutlibraries-compose-core-android` on Android. With this enabled the reported
+     * `uniqueId` is `com.mikepenz:aboutlibraries-compose-core` again, matching what the build script
+     * declares — which keeps `config` overrides and funding mappings keyed on the declared id.
+     *
+     * Note this is *not* about Android build variants — see [filterVariants] and `export.variant`
+     * for those. The unit here is a Gradle module variant, one per Kotlin target.
+     *
+     * Only Gradle `available-at` redirects are collapsed: no coordinate is rewritten unless the
+     * redirecting root module is itself part of the resolved graph. A suffixed coordinate with no
+     * such root module (e.g. `androidx.annotation:annotation-jvm` in a graph that never resolves
+     * `androidx.annotation:annotation`) is untouched — but once the root module is present, the
+     * platform artifact is reported under it even where it was declared directly.
+     * Metadata (name, description, licenses) still comes from the resolved artifact.
+     *
+     * This is independent of [duplicationMode] / [duplicationRule] and applied before them. Note
+     * that the default [DuplicateMode.MERGE] already collapses these artifacts onto *one* entry —
+     * but onto whichever the graph walk reached first, so the surviving id may be a platform one
+     * (`collection-jvm`) even though the entry stands for every platform. Enabling this makes the
+     * survivor deterministic and names it after what the build script declared.
+     *
+     * Pairs with `collect.includeTargets`: the merged entry reports the union of the targets its
+     * artifacts were consumed by.
+     *
+     * ```
+     * aboutLibraries {
+     *   library {
+     *      mergePlatformArtifacts = true
+     *   }
+     * }
+     * ```
+     *
+     * @see duplicationMode
+     */
+    @get:Optional
+    abstract val mergePlatformArtifacts: Property<Boolean>
 }
 
 abstract class LicenseConfig @Inject constructor() {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/BaseAboutLibrariesTask.kt
@@ -94,6 +94,9 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
     val duplicationRule = extension.library.duplicationRule
 
     @Input
+    val mergePlatformArtifacts = extension.library.mergePlatformArtifacts
+
+    @Input
     val mapLicensesToSpdx = extension.license.mapLicensesToSpdx
 
     @Input
@@ -283,12 +286,13 @@ abstract class BaseAboutLibrariesTask : DefaultTask() {
         })
 
         val capturedIncludePlatform = includePlatform.get()
+        val capturedMergePlatformArtifacts = mergePlatformArtifacts.get()
         val capturedConfigs = selectedConfigs
         val dependencyHandler = project.dependencies
         val configContainer = project.configurations
 
         val resolvedProvider = project.provider {
-            val collector = DependencyCollector(capturedIncludePlatform)
+            val collector = DependencyCollector(capturedIncludePlatform, capturedMergePlatformArtifacts)
             val perConfigCoords = LinkedHashMap<String, List<DependencyCoordinates>>(capturedConfigs.size)
             val unionCoords = LinkedHashSet<DependencyCoordinates>()
             for (config in capturedConfigs) {

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -31,6 +31,7 @@ import java.io.InputStream
 
 internal class DependencyCollector(
     private val includePlatform: Boolean = false,
+    private val mergePlatformArtifacts: Boolean = false,
 ) {
 
     /**
@@ -42,7 +43,18 @@ internal class DependencyCollector(
      */
     internal fun loadDependencyCoordinates(root: ResolvedComponentResult): Set<DependencyCoordinates> {
         val coordinates = mutableSetOf<DependencyCoordinates>()
-        loadDependencyCoordinates(root, coordinates, mutableSetOf())
+        // "group:platformArtifact" → module name of the redirect shell it is published under.
+        val redirects = mutableMapOf<String, String>()
+        loadDependencyCoordinates(root, coordinates, redirects, mutableSetOf())
+        if (redirects.isEmpty()) return coordinates
+        // Applied as a pass over the finished set rather than during the walk: a platform artifact
+        // can be reached directly (e.g. a dependency declaring `annotation-jvm`) before the shell
+        // that redirects to it is visited, and the graph walk order is not specified.
+        // Stamped in place — `rootModule` is not part of the coordinate's identity, so mutating it
+        // cannot disturb the set.
+        coordinates.forEach { coords ->
+            redirects["${coords.group}:${coords.artifact}"]?.let { coords.rootModule = it }
+        }
         return coordinates
     }
 
@@ -71,12 +83,24 @@ internal class DependencyCollector(
     private fun loadDependencyCoordinates(
         root: ResolvedComponentResult,
         destination: MutableSet<DependencyCoordinates>,
+        redirects: MutableMap<String, String>,
         seen: MutableSet<ComponentIdentifier>,
         depth: Int = 1,
     ) {
         val id = root.id
+        // Non-null when this component is a pure Gradle `available-at` redirect (a KMP root module
+        // such as `androidx.collection:collection` pointing at `androidx.collection:collection-jvm`).
+        // With `mergePlatformArtifacts` the shell itself is dropped and its module name is
+        // recorded, so the artifact it points at can be reported under the declared coordinate.
+        val redirectTarget = if (mergePlatformArtifacts) root.redirectTargetModule() else null
         var ignoreSuffix: String? = null
         when {
+            redirectTarget != null -> {
+                id as ModuleComponentIdentifier
+                redirects["${id.group}:$redirectTarget"] = id.module
+                ignoreSuffix = " merge platform artifact $redirectTarget into ${id.module}"
+            }
+
             id is ProjectComponentIdentifier -> {
                 ignoreSuffix = " skip project dependency" // Local dependency, do nothing.
             }
@@ -122,6 +146,7 @@ internal class DependencyCollector(
                     loadDependencyCoordinates(
                         selected,
                         destination,
+                        redirects,
                         seen,
                         depth + 1,
                     )
@@ -209,7 +234,10 @@ internal class DependencyCollector(
             LOGGER.debug("--> ArtifactPom for [{}:{}]:\n{}\n\n", pom.groupId, pom.artifactId, pom.pomFile.readText().trim())
         }
 
-        val uniqueId = pom.groupId + ":" + pom.artifactId
+        // With `mergePlatformArtifacts` a KMP platform artifact is reported under the root coordinate it was
+        // resolved through, so the id matches what was declared in the build script. Everything else
+        // (name, description, licenses, …) still comes from the resolved variant's POM.
+        val uniqueId = pom.groupId + ":" + (coordinates.rootModule ?: pom.artifactId)
 
         // check if we shall skip this specific uniqueId
         if (shouldSkip(uniqueId)) return null
@@ -253,6 +281,23 @@ internal class DependencyCollector(
         pom.let(block) ?: parentRawModel.firstOrNull()?.let(block)
 
     private fun ModuleComponentIdentifier.toDependencyCoordinates() = DependencyCoordinates(group, module, version)
+
+    /**
+     * Returns the module name this component redirects to via Gradle `available-at`
+     * (`androidx.collection:collection` → `collection-jvm`), or `null` if it is a regular module.
+     *
+     * A redirecting component carries no artifacts of its own — every one of its variants only
+     * points at a variant of the target module. Requiring *all* variants to redirect, and requiring
+     * a single target within the same group, keeps this from firing on regular modules.
+     */
+    private fun ResolvedComponentResult.redirectTargetModule(): String? {
+        val self = id as? ModuleComponentIdentifier ?: return null
+        val owners = runCatching {
+            variants.map { (it.externalVariant.orElse(null) ?: return null).owner }
+        }.getOrNull()?.takeIf { it.isNotEmpty() } ?: return null
+        val target = owners.distinct().singleOrNull() as? ModuleComponentIdentifier ?: return null
+        return target.module.takeIf { target.group == self.group && it != self.module }
+    }
 
     private fun ResolvedComponentResult.isPlatform(): Boolean {
         val singleVariant = variants.singleOrNull() ?: return false
@@ -304,6 +349,22 @@ internal data class DependencyCoordinates(
     val artifact: String,
     val version: String,
 ) : java.io.Serializable {
+    /**
+     * Module name of the parent (root) module this artifact was resolved *through*, for Gradle
+     * `available-at` redirects as used by Kotlin Multiplatform publications
+     * (`androidx.collection:collection` → `androidx.collection:collection-jvm`).
+     *
+     * Only populated when `mergePlatformArtifacts` is enabled; `null` otherwise, and always `null` for
+     * artifacts that were not reached via a redirect.
+     *
+     * Deliberately outside the constructor, so it takes no part in `equals`/`hashCode`: this
+     * records *how* an artifact was reached, not which artifact it is. The same `g:a:v` can be
+     * reached through a redirect in one configuration and directly in another; were that two
+     * distinct coordinates, its POM would be resolved twice and the two would occupy separate
+     * version slots. `cacheKey()` has always ignored it for the same reason.
+     */
+    var rootModule: String? = null
+
     fun pomCoordinate() = "$group:$artifact:$version@pom"
     fun cacheKey() = "$group:$artifact:$version"
 }

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryPostProcessor.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryPostProcessor.kt
@@ -82,8 +82,12 @@ internal class LibraryPostProcessor(
         val dependencyDataForVariant: Collection<DependencyData>? = if (variant.isNullOrBlank()) {
             selectedConfigs.flatMap { (_, dependencies) -> dependencies }.deduplicateDependencies() ?: emptySet()
         } else {
-            variantToDependencyData[variant] ?: selectedConfigs.flatMap { (_, dependencies) -> dependencies }
-                .deduplicateDependencies()
+            // deduplicate as well on an exact variant hit: with `mergePlatformArtifacts` several
+            // resolved artifacts can collapse onto the same root uniqueId within one configuration.
+            // `deduplicateDependencies()` returns null for an empty result, so an exact hit with no
+            // dependencies must not fall through to the prefix-match branch below.
+            variantToDependencyData[variant]?.let { it.deduplicateDependencies() ?: emptySet() }
+                ?: selectedConfigs.flatMap { (_, dependencies) -> dependencies }.deduplicateDependencies()
         }
 
         // uniqueId -> Kotlin target names consuming it. Sorted so the generated output is

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
@@ -1,0 +1,236 @@
+package com.mikepenz.aboutlibraries.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Verifies `aboutLibraries.library.mergePlatformArtifacts`: Kotlin Multiplatform artifacts reached
+ * via a Gradle `available-at` redirect are reported under the root coordinate that was declared,
+ * while artifacts genuinely published under a suffixed coordinate stay untouched.
+ *
+ * `androidx.collection:collection` is a KMP publication: on a JVM classpath it redirects to
+ * `androidx.collection:collection-jvm`.
+ */
+class MergePlatformArtifactsFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    @Test
+    fun `root and platform artifact are both collected when merging is disabled`() {
+        val json = runExport(mergePlatformArtifacts = false)
+
+        // `duplicationMode = KEEP` (set by runExport) keeps both entries visible; with the default
+        // MERGE they are collapsed onto whichever of the two the graph walk happened to reach first
+        assertTrue(json.contains("\"androidx.collection:collection-jvm\""), "Expected platform artifact id. Output:\n$json")
+        assertTrue(json.contains("\"androidx.collection:collection\""), "Expected redirect shell id. Output:\n$json")
+    }
+
+    @Test
+    fun `platform artifacts are merged regardless of the order the graph is walked in`() {
+        // `annotation-jvm` is declared first, so it is reached directly before the `annotation`
+        // redirect shell that `collection` pulls in transitively. The merge must not depend on
+        // which path reaches the platform artifact first.
+        val json = runExport(
+            mergePlatformArtifacts = true,
+            dependencies = listOf("androidx.annotation:annotation-jvm:1.9.1", "androidx.collection:collection:1.5.0"),
+        )
+
+        assertTrue(json.contains("\"androidx.annotation:annotation\""), "Expected declared root id. Output:\n$json")
+        assertFalse(json.contains("\"androidx.annotation:annotation-jvm\""), "Platform artifact id must be replaced. Output:\n$json")
+    }
+
+    @Test
+    fun `platform artifacts are reported under the declared root coordinate when merging`() {
+        val json = runExport(mergePlatformArtifacts = true)
+
+        assertTrue(json.contains("\"androidx.collection:collection\""), "Expected declared root id. Output:\n$json")
+        assertFalse(json.contains("\"androidx.collection:collection-jvm\""), "Platform artifact id must be replaced")
+        // metadata still comes from the resolved artifact's POM
+        assertTrue(json.contains("Standalone efficient collections."), "Description of the resolved artifact should be kept")
+    }
+
+    @Test
+    fun `non-multiplatform dependency trees are byte-identical with and without merging`() {
+        // guards against the detection widening beyond `available-at` redirects: a plain JVM tree
+        // has no redirect shells at all, so enabling the option must be a no-op
+        val dependencies = listOf("com.google.code.gson:gson:2.11.0", "org.slf4j:slf4j-api:2.0.16")
+
+        val disabled = runExport(mergePlatformArtifacts = false, dependencies = dependencies)
+        val enabled = runExport(mergePlatformArtifacts = true, dependencies = dependencies)
+
+        assertEquals(disabled, enabled, "Merging must not alter output for non-KMP dependencies")
+    }
+
+    @Test
+    fun `suffixed coordinates without a redirect are untouched when merging`() {
+        // no KMP root module in the graph, so there is nothing to merge into — the `-jvm` suffix
+        // must not be stripped by name
+        val json = runExport(mergePlatformArtifacts = true, dependencies = listOf("androidx.annotation:annotation-jvm:1.9.1"))
+
+        assertTrue(json.contains("\"androidx.annotation:annotation-jvm\""), "Suffixed id without redirect must be kept. Output:\n$json")
+        assertFalse(json.contains("\"androidx.annotation:annotation\""), "Nothing should have been merged. Output:\n$json")
+    }
+
+    /**
+     * The case the option exists for, and the only one a `java-library` project cannot show: a real
+     * multiplatform *consumer*, where one declared dependency resolves to a different artifact per
+     * target.
+     *
+     * Without merging, the default [DuplicateMode.MERGE] still collapses the three coordinates onto
+     * one entry — but onto whichever the graph walk reached first. That survivor is named for a
+     * single platform while standing for all of them, which `collect.includeTargets` makes plainly
+     * visible: an entry called `collection-js` reporting that it is consumed by `jvm`.
+     *
+     * With merging the id is the declared root coordinate and the targets are the union, so the
+     * name and the targets finally agree.
+     */
+    @Test
+    fun `merged entry is named for the declared root and carries the union of its targets`() {
+        val merged = extractEntry(runKmpExport(mergePlatformArtifacts = true), "androidx.collection:collection")
+            ?: error("expected the declared root coordinate to be reported")
+        assertEquals(setOf("js", "jvm"), targetsOf(merged) - "metadata", "Entry: $merged")
+
+        val unmerged = runKmpExport(mergePlatformArtifacts = false)
+        assertFalse(
+            unmerged.contains("\"uniqueId\":\"androidx.collection:collection\","),
+            "without merging the survivor is a platform artifact, not the root. Output:\n$unmerged"
+        )
+    }
+
+    private fun targetsOf(entry: String): Set<String> =
+        Regex("\"targets\":\\[(.*?)]").find(entry)?.groupValues?.get(1)
+            ?.split(",")?.mapNotNull { it.trim().trim('"').takeIf(String::isNotEmpty) }?.toSet()
+            ?: error("no `targets` field in entry: $entry")
+
+    /** Slices out a single library object by `uniqueId` from the (non pretty-printed) output. */
+    private fun extractEntry(json: String, uniqueId: String): String? {
+        val keyIdx = json.indexOf("\"uniqueId\":\"$uniqueId\",")
+        if (keyIdx < 0) return null
+        var start = keyIdx
+        while (start > 0 && json[start] != '{') start--
+        var depth = 0
+        for (end in start until json.length) {
+            when (json[end]) {
+                '{' -> depth++
+                '}' -> if (--depth == 0) return json.substring(start, end + 1)
+            }
+        }
+        return null
+    }
+
+    /**
+     * A Kotlin Multiplatform project with two targets, so `androidx.collection:collection` resolves
+     * to `collection-jvm` on one and `collection-js` on the other. `duplicationMode` is left at its
+     * default here — the point is what a normal consumer sees.
+     */
+    private fun runKmpExport(mergePlatformArtifacts: Boolean): String {
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement { repositories { gradlePluginPortal(); mavenCentral(); google() } }
+            rootProject.name = "kmp-consumer"
+            """.trimIndent()
+        )
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            buildscript {
+                repositories { mavenCentral(); google(); gradlePluginPortal() }
+                dependencies {
+                    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                    classpath(files($pluginClasspath))
+                }
+            }
+
+            apply(plugin = "org.jetbrains.kotlin.multiplatform")
+            apply(plugin = "com.mikepenz.aboutlibraries.plugin")
+
+            repositories { mavenCentral(); google() }
+
+            extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
+                jvm()
+                js { nodejs() }
+                sourceSets.getByName("commonMain").dependencies {
+                    implementation("androidx.collection:collection:1.5.0")
+                }
+            }
+
+            extensions.configure<com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension>("aboutLibraries") {
+                offlineMode = true
+                collect { includeTargets = true }
+                library { mergePlatformArtifacts = $mergePlatformArtifacts }
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+        return File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+    }
+
+    private val kotlinVersion: String = System.getProperty("test.kotlin.version")
+        ?: error("test.kotlin.version system property must be set by the test task")
+
+    private val pluginClasspath: String by lazy {
+        val resource = javaClass.classLoader.getResource("plugin-under-test-metadata.properties")
+            ?: error("plugin-under-test-metadata.properties not found on test classpath")
+        val props = java.util.Properties().apply { resource.openStream().use { load(it) } }
+        val cp = props.getProperty("implementation-classpath")
+            ?: error("implementation-classpath missing from plugin-under-test-metadata.properties")
+        cp.split(File.pathSeparator).joinToString(", ") { "files(\"${it.replace("\\", "\\\\")}\")" }
+    }
+
+    private fun runExport(
+        mergePlatformArtifacts: Boolean,
+        dependencies: List<String> = listOf("androidx.collection:collection:1.5.0", "androidx.annotation:annotation-jvm:1.9.1"),
+    ): String {
+        File(projectDir, "settings.gradle.kts").writeText("""rootProject.name = "test-project"""")
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("java-library")
+                id("com.mikepenz.aboutlibraries.plugin")
+            }
+
+            repositories {
+                mavenCentral()
+                google()
+            }
+
+            dependencies {
+                ${dependencies.joinToString("\n                ") { "implementation(\"$it\")" }}
+            }
+
+            aboutLibraries {
+                offlineMode = true
+                library {
+                    mergePlatformArtifacts = $mergePlatformArtifacts
+                    duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.KEEP
+                }
+            }
+            """.trimIndent()
+        )
+
+        @Suppress("WithPluginClasspathUsage")
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("exportLibraryDefinitions", "--stacktrace")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitions")?.outcome)
+
+        val outputFile = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json")
+        assertTrue(outputFile.exists(), "Output file should be created")
+        return outputFile.readText()
+    }
+}


### PR DESCRIPTION
Closes #1430

> [!NOTE]
> Built on top of #1445, so the diff shows that PR's commits until it merges. Review the top commit only.

## Problem

Since 14.1.0 a dependency declared as `com.mikepenz:aboutlibraries-compose-core` can be reported as `com.mikepenz:aboutlibraries-compose-core-android`, which makes it hard to match generated entries against what the build script declares (breaking `config` overrides keyed on the declared id).

Gradle's resolution graph contains **both** the KMP root module — an `available-at` redirect shell, e.g. `androidx.collection:collection` — and the resolved platform artifact `androidx.collection:collection-jvm`.

Worth being precise about what goes wrong, because it is narrower than "both become entries": the default `DuplicateMode.MERGE` **already** collapses them onto a single entry today. What it does not do is pick *which* one survives — `minByOrNull { name.length }` over graph-iteration order does. So the bug is not a duplicate entry, it is a single entry named after one platform while standing for all of them.

That naming is harmless as long as nothing else on the entry contradicts it. `collect.includeTargets` (#1445) is exactly such a thing. Two-target (jvm + js) consumer, merging off, `duplicationMode = KEEP` to show the raw attribution:

```
androidx.collection:collection       targets: ["js", "jvm", "metadata"]   <- the redirect shell
androidx.collection:collection-js    targets: ["js"]
androidx.collection:collection-jvm   targets: ["jvm"]
```

Each is correct in isolation. But at the default `duplicationMode = MERGE` those three collapse, and the surviving entry has to carry the **union** of their targets — dropping the discarded siblings' targets would make the entry under-report, so a consumer filtering `"jvm" in it.targets` would silently lose the library from its jvm list. Union is the safe choice, and it leaves:

```
androidx.collection:collection-js    targets: ["js", "jvm", "metadata"]
```

An id that says one platform on an entry that stands for three.

## Solution

```kotlin
aboutLibraries {
    library {
        mergePlatformArtifacts = true
    }
}
```

The redirect shell is dropped and its module name carried onto the platform artifact, so the reported `uniqueId` is the declared coordinate and is stable:

```
androidx.collection:collection       targets: ["js", "jvm", "metadata"]
```

Note this is not the arbitrary survivor getting patched up after the fact. `collection-js` and `collection-jvm` both carry `rootModule = collection`, so they share a `uniqueId` *before* target attribution runs — the union is computed on the correct id, and `processDuplicates` is left with nothing to collapse. Id and targets agree because they were never separated.

- Detection reads `ResolvedComponentResult.variants[].externalVariant`. Only a component whose variants *all* redirect to a single target within the same group is treated as a shell — no suffix stripping, so `androidx.annotation:annotation-jvm` declared directly stays untouched.
- No additional artifact resolution; configuration-cache and project-isolation safe.
- Metadata (name, description, licenses) still comes from the resolved artifact's POM.
- Independent of `duplicationMode` / `duplicationRule`, applied before them.
- Defaults to `false` — existing output is unchanged.

`rootModule` is held outside `DependencyCoordinates`' constructor so it takes no part in `equals`/`hashCode`. It records *how* an artifact was reached, not which artifact it is; the same `g:a:v` reached through a redirect in one configuration and directly in another therefore stays one coordinate instead of being spread over two version slots and resolved twice. `cacheKey()` already ignored it for the same reason.

`LibraryPostProcessor` also deduplicates on an exact variant match, since several platform artifacts can now collapse onto the same root id within one configuration — and an exact hit that dedups to empty must not fall through to the prefix-match branch.

## Naming

Previously `mergeVariants`. Renamed because "variant" already has a settled and different meaning throughout this plugin — `filterVariants`, `includeTestVariants`, `export.variant`, `PROP_EXPORT_VARIANT` all denote an **Android build variant**. Read against those, `mergeVariants` sounds like it merges the debug and release reports. `mergePlatformArtifacts` says what actually merges, and stays distinct from the `targets` field added in #1445.

## Tests

`MergePlatformArtifactsFunctionalTest`, resolving real `androidx.collection` / `androidx.annotation` coordinates:

- default: root and platform artifact both reported (unchanged behaviour)
- enabled: only `androidx.collection:collection` remains, metadata preserved
- enabled, suffixed coordinate with no redirect in the graph: `annotation-jvm` kept as-is
- enabled, platform artifact reached before its shell: merge is independent of graph walk order
- non-multiplatform trees: byte-identical with and without the option
- **two-target (jvm + js) multiplatform consumer** with `collect.includeTargets` and `duplicationMode` left at its default: the merged entry is named for the declared root and carries the union of its targets

That last one is new. Every other test in the class runs on a `java-library` project, so none of them exercised a real multiplatform *consumer* — the case the option exists for.

`./gradlew :plugin:test` passes.

## Open question

Given the merging fixes output that is arguably wrong today rather than adding a new capability, should this stay opt-in, or default to on? Left opt-in here.
