### PR TITLE
ci: add OpenSSF Scorecard and scope workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - '*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   publish_archives:
     name: Publish Archives

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - develop
 
+permissions: {}
+
 jobs:
   gradle-dependency-detection:
     runs-on: ubuntu-latest

--- a/.github/workflows/record-screenshots.yml
+++ b/.github/workflows/record-screenshots.yml
@@ -8,10 +8,14 @@ on:
         required: false
         default: ''
 
+permissions: {}
+
 jobs:
   record:
     name: Record Paparazzi Screenshots
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # commits the re-recorded golden images back to the branch
 
     steps:
       - name: Checkout the repo

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: "Scorecard"
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 4 * * 1'
+  push:
+    branches: [ "develop" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF results to code scanning
+      id-token: write # publish the results to the OpenSSF API (badge)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload to code scanning"
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.mikepenz/aboutlibraries-core?style=for-the-badge)](https://search.maven.org/artifact/com.mikepenz/aboutlibraries-core)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.mikepenz.aboutlibraries.plugin?label=Gradle%20Plugin&style=for-the-badge)](https://plugins.gradle.org/plugin/com.mikepenz.aboutlibraries.plugin)
 [![Apache 2.0 License](https://img.shields.io/github/license/mikepenz/AboutLibraries?style=for-the-badge)](https://github.com/mikepenz/AboutLibraries/blob/develop/LICENSE)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/mikepenz/AboutLibraries?style=for-the-badge&label=Scorecard)](https://scorecard.dev/viewer/?uri=github.com/mikepenz/AboutLibraries)
 
 This library collects dependency details, including licenses at compile time, and offers simple APIs to visualize these in the app.
 *No runtime overhead.* Strong caching. Supports any Gradle dependency.


### PR DESCRIPTION
Same hardening pass already applied across the action repos, adapted for this one.

### Scorecard

New `.github/workflows/scorecard.yml` — weekly, on push to `develop`, and on branch protection rule changes. `publish_results: true` feeds the OpenSSF API, so the score flows into deps.dev against the Maven coordinates; SARIF goes to code scanning so findings land in the Security tab.

`develop` is this repo's default branch — `scorecard-action` hard-fails with `only default branch is supported` anywhere else.

### Token permissions

Three workflows had no top-level `permissions:` block, so any job without its own inherited the full repository default token scope.

This repo needed more care than the action repos, where a blanket `permissions: {}` was safe because every job already declared its own. Here several jobs deliberately inherit, so an empty top-level default would have broken them:

- **`ci.yml`** → top-level `contents: read`. `publish_archives` has no block of its own and inherits it. It only needs to check out — everything it publishes goes through external credentials (`GRADLE_PUBLISH_KEY`, `NEXUS_*`, `SIGNING_*`), not the Actions token. `build` and `release` already declare their own (`contents: read` / `contents: write`), so they are unaffected — the GitHub release upload keeps its write scope.
- **`gradle-dependency-submission.yml`** → top-level `permissions: {}`. Its only job already declares `contents: write`.
- **`record-screenshots.yml`** → top-level `permissions: {}`, plus an explicit `contents: write` on the `record` job. That job runs `git push` to commit re-recorded Paparazzi golden images, so it genuinely needs write and would have broken under a bare `{}`.

`pr-checks.yml` and `static.yml` already had top-level blocks and are untouched.

### Not addressed

`Signed-Releases` will stay low regardless. Scorecard reads GitHub release *assets*, and the current ones are sample app builds (`AboutLibraries-v15.0.4-c150004-release.apk`/`.aab`) with no `.asc`/`.sig`/`.intoto.jsonl` beside them — the GPG signatures Maven Central requires are invisible to it. Attaching build provenance attestation would be the fix, as a separate change.

`Code-Review` and `Branch-Protection` are repo settings rather than code, and are untouched here.