### PR TITLE
build: prepare plugin for AGP 10, cover strict behavior flags with tests

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -67,7 +67,8 @@ dependencies {
     implementation(libs.maven.modelBuilder)
 
     // add better android support
-    compileOnly(baseLibs.android.gradlePlugin)
+    // `gradle-api` (not `gradle`): AGP 10 hides all internal classes, only this artifact stays available
+    compileOnly("com.android.tools.build:gradle-api:${baseLibs.versions.agp.get()}")
 
     // lint rules
     lintChecks(baseLibs.android.lint.gradle)

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/Agp10CompatibilityTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/Agp10CompatibilityTest.kt
@@ -1,0 +1,136 @@
+package com.mikepenz.aboutlibraries.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.Properties
+
+/**
+ * Verifies the plugin works under the strict AGP 10.0 behavior flags documented in
+ * https://developer.android.com/build/releases/gradle-plugin-roadmap#agp-10:
+ * `android.newDsl=true` (only the new DSL / Variant API interfaces exist) and
+ * `android.builtInKotlin=true` (no `kotlin-android` opt-out).
+ *
+ * Covers the `com.android.application` and `com.android.library` paths of
+ * [configureAndroidTasks], which are otherwise only exercised for
+ * `com.android.kotlin.multiplatform.library` (see [KmpAndroidFunctionalTest]).
+ */
+class Agp10CompatibilityTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val agpVersion: String = System.getProperty("test.agp.version")
+        ?: error("test.agp.version system property must be set by the test task")
+
+    @Test
+    fun `library module registers and runs variant tasks under AGP 10 behavior flags`() {
+        setupAndroidProject(projectDir, "com.android.library", "com.android.build.api.dsl.LibraryExtension")
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitionsRelease", "prepareLibraryDefinitionsRelease", "--stacktrace")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitionsRelease")?.outcome)
+        // registered via variant.sources.res.addGeneratedSourceDirectory (Sources API)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":prepareLibraryDefinitionsRelease")?.outcome)
+
+        val content = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
+        assertTrue(content.contains("com.google.code.gson:gson"), "Dependency should be collected. Output: $content")
+    }
+
+    @Test
+    fun `application module registers and runs variant tasks under AGP 10 behavior flags`() {
+        setupAndroidProject(projectDir, "com.android.application", "com.android.build.api.dsl.ApplicationExtension")
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("exportLibraryDefinitionsRelease", "prepareLibraryDefinitionsRelease", "--stacktrace")
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":exportLibraryDefinitionsRelease")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":prepareLibraryDefinitionsRelease")?.outcome)
+    }
+
+    private val pluginClasspath: String by lazy {
+        val resource = javaClass.classLoader.getResource("plugin-under-test-metadata.properties")
+            ?: error("plugin-under-test-metadata.properties not found on test classpath")
+        val props = Properties().apply { resource.openStream().use { load(it) } }
+        val cp = props.getProperty("implementation-classpath")
+            ?: error("implementation-classpath missing from plugin-under-test-metadata.properties")
+        cp.split(File.pathSeparator).joinToString(", ") { "files(\"${it.replace("\\", "\\\\")}\")" }
+    }
+
+    private fun setupAndroidProject(projectDir: File, androidPluginId: String, extensionType: String) {
+        File(projectDir, "gradle.properties").writeText(
+            """
+            android.useAndroidX=true
+            # enforce AGP 10.0 behavior while running on AGP 9.x
+            android.newDsl=true
+            android.builtInKotlin=true
+            """.trimIndent()
+        )
+
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    google()
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+            dependencyResolutionManagement {
+                repositories {
+                    google()
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "agp10-test"
+            """.trimIndent()
+        )
+
+        File(projectDir, "src/main").mkdirs()
+        File(projectDir, "src/main/AndroidManifest.xml").writeText("<manifest />")
+
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            buildscript {
+                repositories {
+                    google()
+                    mavenCentral()
+                    gradlePluginPortal()
+                }
+                dependencies {
+                    classpath("com.android.tools.build:gradle:$agpVersion")
+                    classpath(files($pluginClasspath))
+                }
+            }
+
+            apply(plugin = "$androidPluginId")
+            apply(plugin = "com.mikepenz.aboutlibraries.plugin")
+
+            extensions.configure<$extensionType>("android") {
+                namespace = "com.mikepenz.aboutlibraries.agp10test"
+                compileSdk = 35
+                defaultConfig {
+                    minSdk = 24
+                }
+            }
+
+            dependencies {
+                "implementation"("com.google.code.gson:gson:2.11.0")
+            }
+
+            extensions.configure<com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension>("aboutLibraries") {
+                offlineMode = true
+            }
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
## Why

[AGP roadmap — AGP 10.0](https://developer.android.com/build/releases/gradle-plugin-roadmap#agp-10) removes the legacy Variant API and DSL, and hides AGP internals from the `com.android.tools.build:gradle` artifact.

## Audit result

No source changes required. The plugin uses none of the removed APIs:

| AGP 10 removal | Status |
|---|---|
| `applicationVariants` / `libraryVariants` / `testVariants` / `variantFilter` | not used; already on `androidComponents.onVariants()` (`AboutLibrariesPluginAndroidExtension.kt:16-49`) |
| `registerResGeneratingTask` / `registerJavaGeneratingTask` | not used; Sources API `variant.sources.res.addGeneratedSourceDirectory` (`:66`) |
| Direct task access, `buildConfigField`, Transform API, `sdkDirectory`, `bootClasspath` | not used anywhere in the repo |
| `android.newDsl` / `android.builtInKotlin` opt-outs | never set; `:app` also configures cleanly with `-Pandroid.newDsl=true` |
| Config cache / Project Isolation prerequisite | already covered by `ConfigurationCacheTest` and `IsolatedProjectsTest` |

## Changes

- Compile against `com.android.tools.build:gradle-api` instead of `com.android.tools.build:gradle` — AGP 10 hides internals in the latter, and the plugin only uses public `com.android.build.api.*` types.
- Add `Agp10CompatibilityTest`, covering the `com.android.application` and `com.android.library` paths of `configureAndroidTasks` with `android.newDsl=true` + `android.builtInKotlin=true`. Previously only `com.android.kotlin.multiplatform.library` was exercised.

## Testing

`./gradlew test` in `plugin-build` — all green against AGP 9.3.1.