### PR TITLE
fix(plugin): keep the KMP root module when `mergePlatformArtifacts` merges

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
@@ -470,7 +470,10 @@ abstract class LibraryConfig @Inject constructor() {
      * such root module (e.g. `androidx.annotation:annotation-jvm` in a graph that never resolves
      * `androidx.annotation:annotation`) is untouched — but once the root module is present, the
      * platform artifact is reported under it even where it was declared directly.
-     * Metadata (name, description, licenses) still comes from the resolved artifact.
+     * Metadata (name, description, licenses) comes from the root module's POM, which a Kotlin
+     * Multiplatform publication fills in identically to its platform artifacts'. It is also the
+     * only POM available for Kotlin/Native targets: a klib platform artifact resolves to no POM
+     * at all, so the root module is what keeps such a dependency (and its `targets`) reported.
      *
      * This is independent of [duplicationMode] / [duplicationRule] and applied before them. Note
      * that the default [DuplicateMode.MERGE] already collapses these artifacts onto *one* entry —

--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/DependencyCollector.kt
@@ -90,15 +90,22 @@ internal class DependencyCollector(
         val id = root.id
         // Non-null when this component is a pure Gradle `available-at` redirect (a KMP root module
         // such as `androidx.collection:collection` pointing at `androidx.collection:collection-jvm`).
-        // With `mergePlatformArtifacts` the shell itself is dropped and its module name is
-        // recorded, so the artifact it points at can be reported under the declared coordinate.
+        // With `mergePlatformArtifacts` its module name is recorded, so the artifact it points at
+        // can be reported under the declared coordinate.
         val redirectTarget = if (mergePlatformArtifacts) root.redirectTargetModule() else null
         var ignoreSuffix: String? = null
         when {
             redirectTarget != null -> {
                 id as ModuleComponentIdentifier
                 redirects["${id.group}:$redirectTarget"] = id.module
-                ignoreSuffix = " merge platform artifact $redirectTarget into ${id.module}"
+                // The shell is kept, not dropped: its coordinate already *is* the declared root id,
+                // so it deduplicates against the platform artifact rather than adding an entry. It
+                // is also the only one that survives for Kotlin/Native targets — a klib platform
+                // artifact (`…-iossimulatorarm64`) cannot be resolved by the attribute-less
+                // detached configuration that fetches POMs, so it yields no metadata and, without
+                // the shell, the dependency (and its `targets`) would vanish entirely.
+                destination += id.toDependencyCoordinates()
+                ignoreSuffix =" merge platform artifact $redirectTarget into ${id.module}"
             }
 
             id is ProjectComponentIdentifier -> {

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
@@ -104,6 +104,30 @@ class MergePlatformArtifactsFunctionalTest {
         )
     }
 
+    /**
+     * A Kotlin/Native platform artifact (`androidx.collection:collection-linuxx64`) is a klib
+     * module: the attribute-less detached configuration that fetches POMs cannot choose between its
+     * variants, so it resolves to no POM and produces no metadata at all. Merging must therefore
+     * keep the `available-at` shell rather than trading it for an artifact that evaporates —
+     * otherwise the dependency loses its native `targets`, and a native-only one disappears.
+     *
+     * `filterVariants` narrows collection to the two target compile classpaths, which is what makes
+     * the loss observable: with every configuration collected the `metadata` one still contributes
+     * the root coordinate directly and masks it.
+     */
+    @Test
+    fun `native targets survive merging even though their platform artifact has no resolvable POM`() {
+        val json = runKmpExport(
+            mergePlatformArtifacts = true,
+            targets = listOf("jvm()", "iosSimulatorArm64()"),
+            collect = """all = true; includeTargets = true; filterVariants.addAll("jvmCompileClasspath", "iosSimulatorArm64CompileKlibraries")""",
+        )
+        val merged = extractEntry(json, "androidx.collection:collection")
+            ?: error("expected the declared root coordinate to be reported. Output:\n$json")
+
+        assertEquals(setOf("iosSimulatorArm64", "jvm"), targetsOf(merged), "Entry: $merged")
+    }
+
     private fun targetsOf(entry: String): Set<String> =
         Regex("\"targets\":\\[(.*?)]").find(entry)?.groupValues?.get(1)
             ?.split(",")?.mapNotNull { it.trim().trim('"').takeIf(String::isNotEmpty) }?.toSet()
@@ -130,7 +154,11 @@ class MergePlatformArtifactsFunctionalTest {
      * to `collection-jvm` on one and `collection-js` on the other. `duplicationMode` is left at its
      * default here — the point is what a normal consumer sees.
      */
-    private fun runKmpExport(mergePlatformArtifacts: Boolean): String {
+    private fun runKmpExport(
+        mergePlatformArtifacts: Boolean,
+        targets: List<String> = listOf("jvm()", "js { nodejs() }"),
+        collect: String = "includeTargets = true",
+    ): String {
         File(projectDir, "settings.gradle.kts").writeText(
             """
             pluginManagement { repositories { gradlePluginPortal(); mavenCentral(); google() } }
@@ -153,8 +181,7 @@ class MergePlatformArtifactsFunctionalTest {
             repositories { mavenCentral(); google() }
 
             extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
-                jvm()
-                js { nodejs() }
+                ${targets.joinToString("\n                ")}
                 sourceSets.getByName("commonMain").dependencies {
                     implementation("androidx.collection:collection:1.5.0")
                 }
@@ -162,7 +189,7 @@ class MergePlatformArtifactsFunctionalTest {
 
             extensions.configure<com.mikepenz.aboutlibraries.plugin.AboutLibrariesExtension>("aboutLibraries") {
                 offlineMode = true
-                collect { includeTargets = true }
+                collect { $collect }
                 library { mergePlatformArtifacts = $mergePlatformArtifacts }
             }
             """.trimIndent()


### PR DESCRIPTION
Reported by @sergeys-opera in #1445, reproduced by 027b24a.

With `mergePlatformArtifacts = true` a Kotlin/Native dependency loses its native `targets`, and a native-only one disappears from the output entirely:

```diff
     "uniqueId": "androidx.lifecycle:lifecycle-viewmodel-savedstate",
     "targets": [
         "android",
-        "iosSimulatorArm64"
     ]
```

## Root cause

POMs are fetched through an attribute-less detached configuration (`BaseAboutLibrariesTask.fetchPomBatch`). A klib platform artifact cannot be selected from one:

```
VariantSelectionByAttributesException: Cannot choose between the available variants of
  androidx.savedstate:savedstate-iossimulatorarm64:1.4.0
```

`artifactView { lenient(true) }` drops it silently, `getPomInfo` then yields no `DependencyData`, and the coordinate contributes neither metadata nor a target.

That hole predates this option — it was invisible because the `available-at` root module (`androidx.savedstate:savedstate`) resolves fine and stood in for its platform artifacts. Merging then traded the shell for an artifact that evaporates.

## Fix

The shell is kept rather than dropped. Its coordinate already *is* the declared root id, so it deduplicates against the platform artifact by `uniqueId` instead of adding an entry, and `targets` are unioned across both. Metadata comes from the root POM, which a multiplatform publication fills in identically to its platform artifacts' — and which is the only POM that exists for native targets.

Not done: probing the failing resolution with `lenient(false)` to fall back per-coordinate. It would fix native metadata more broadly but costs the build cache.

## Why the sample never showed it

Reproducing needs `collect.filterVariants` narrowed to the target compile classpaths. With every configuration collected, the `metadata` one contributes the root coordinates directly and masks the loss.

## Verification

- New functional test `native targets survive merging even though their platform artifact has no resolvable POM`: `jvm()` + `iosSimulatorArm64()` consumer with `filterVariants` narrowed. `androidx.collection:collection` reports both targets; fails pre-fix with `["jvm"]`.
- Full plugin suite: 76 tests, 0 failures.
- KMP sample with the reporter's configuration: **111 libraries, 50 carrying `iosSimulatorArm64`** — matching the merge-disabled baseline, now under the declared root coordinates. `androidx.navigationevent:navigationevent`, `org.jetbrains.compose.ui:ui-uikit` and `org.jetbrains.skiko:skiko` are back.
- The sample's own committed output is byte-identical.
