### PR TITLE
fix(plugin): don't merge sibling modules sharing POM name and description

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
@@ -10,23 +10,27 @@ fun List<Library>.processDuplicates(
     duplicateMode: DuplicateMode,
     duplicateRule: DuplicateRule,
 ): List<Library> {
-    fun mappedLibs(): Map<String, List<Library>> {
+    fun mappedLibs(): List<List<Library>> {
         return this.groupBy {
             when (duplicateRule) {
                 DuplicateRule.GROUP -> it.groupId + it.licenses.joinToString(",")
                 DuplicateRule.SIMPLE -> it.groupId + it.name
                 DuplicateRule.EXACT -> it.groupId + it.name + it.description?.toMD5()
             }
-        }
+        }.values.flatMap { it.clusterByArtifactId() }
     }
 
     when (duplicateMode) {
         DuplicateMode.MERGE -> {
             val deDuplicatedList = mutableListOf<Library>()
-            mappedLibs().forEach { (_, group) ->
+            mappedLibs().forEach { group ->
                 val kept = if (group.size > 1) {
-                    // on duplicates, assumption is the shorter title is the base dependency
-                    group.minByOrNull { it.name?.length ?: it.description?.length ?: Int.MAX_VALUE } ?: group.first()
+                    // on duplicates, assumption is the shorter title is the base dependency; on a
+                    // tie (a KMP publication names every platform artifact identically) the
+                    // shortest id is the root module the others are platform variants of
+                    group.minWithOrNull(
+                        compareBy({ it.name?.length ?: it.description?.length ?: Int.MAX_VALUE }, { it.uniqueId.length })
+                    ) ?: group.first()
                 } else {
                     group.first()
                 }
@@ -41,7 +45,7 @@ fun List<Library>.processDuplicates(
         }
 
         DuplicateMode.LINK -> {
-            mappedLibs().forEach { (_, group) ->
+            mappedLibs().forEach { group ->
                 if (group.size > 1) {
                     val allAssociated = group.map { it.uniqueId }
                     group.forEach {
@@ -57,6 +61,33 @@ fun List<Library>.processDuplicates(
             return this
         }
     }
+}
+
+/**
+ * Splits libraries the [DuplicateRule] considered equal into clusters that really are one library
+ * published under several coordinates: a Kotlin Multiplatform publication such as
+ * `androidx.collection:collection` + `collection-jvm`, where the platform artifact id is the root
+ * id plus a target suffix.
+ *
+ * Sibling modules of one project routinely share the POM `name` and `description` — e.g.
+ * `com.materialkolor:material-kolor` and `com.materialkolor:material-color-utilities`, both named
+ * "MaterialKolor" with the same description. Those are distinct libraries, and merging them
+ * silently dropped one of them.
+ */
+private fun List<Library>.clusterByArtifactId(): List<List<Library>> {
+    if (size < 2) return listOf(this)
+    // `Library.artifactId` is the full `group:artifact:version` — the module name is what a
+    // platform suffix is appended to
+    fun Library.module() = uniqueId.substringAfterLast(':')
+
+    // shortest first, so the root module is the one every platform artifact attaches to
+    val clusters = mutableListOf<Pair<String, MutableList<Library>>>() // root module -> members
+    for (library in sortedBy { it.module().length }) {
+        val module = library.module()
+        val cluster = clusters.firstOrNull { (root, _) -> module.startsWith("$root-") }
+        if (cluster != null) cluster.second += library else clusters += module to mutableListOf(library)
+    }
+    return clusters.map { it.second }
 }
 
 fun Library.merge(with: Library) {

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/KmpAndroidFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/KmpAndroidFunctionalTest.kt
@@ -111,8 +111,9 @@ class KmpAndroidFunctionalTest {
         val content = File(projectDir, "build/generated/aboutLibraries/aboutlibraries.json").readText()
         val gson = extractLibraryEntry(content, "com.google.code.gson:gson")
             ?: error("gson entry not found in output: $content")
-        // resolves through the KMP `available-at` redirect, so it lands under its platform artifact
-        val annotation = extractLibraryEntry(content, "androidx.annotation:annotation-jvm")
+        // resolves through the KMP `available-at` redirect; the redirect shell and the platform
+        // artifact are merged onto the root module they share
+        val annotation = extractLibraryEntry(content, "androidx.annotation:annotation")
             ?: error("androidx.annotation entry not found in output: $content")
 
         // no raw configuration name may leak into the field

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/MergePlatformArtifactsFunctionalTest.kt
@@ -97,10 +97,12 @@ class MergePlatformArtifactsFunctionalTest {
             ?: error("expected the declared root coordinate to be reported")
         assertEquals(setOf("js", "jvm"), targetsOf(merged) - "metadata", "Entry: $merged")
 
+        // without merging the platform artifacts are still collapsed by `DuplicateMode.MERGE`, but
+        // only into the root module they are variants of — their own ids are gone either way
         val unmerged = runKmpExport(mergePlatformArtifacts = false)
         assertFalse(
-            unmerged.contains("\"uniqueId\":\"androidx.collection:collection\","),
-            "without merging the survivor is a platform artifact, not the root. Output:\n$unmerged"
+            unmerged.contains("\"uniqueId\":\"androidx.collection:collection-js\","),
+            "platform artifacts must not survive the duplicate merge. Output:\n$unmerged"
         )
     }
 

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtilTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtilTest.kt
@@ -1,0 +1,56 @@
+package com.mikepenz.aboutlibraries.plugin.util
+
+import com.mikepenz.aboutlibraries.plugin.DuplicateMode
+import com.mikepenz.aboutlibraries.plugin.DuplicateRule
+import com.mikepenz.aboutlibraries.plugin.mapping.Library
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LibraryUtilTest {
+
+    private fun library(uniqueId: String, name: String, description: String = "Material You dynamic color") = Library(
+        uniqueId = uniqueId,
+        artifactVersion = "5.0.0",
+        name = name,
+        description = description,
+        website = null,
+        developers = emptyList(),
+        organization = null,
+        scm = null,
+    )
+
+    /**
+     * https://github.com/mikepenz/AboutLibraries/issues/1430 — sibling modules of one project share
+     * the POM `name` and `description`, which made every duplicate rule consider them equal. Only
+     * the platform artifacts of the *same* module may be merged.
+     */
+    @Test
+    fun `sibling modules sharing name and description are not merged`() {
+        val libraries = listOf(
+            library("com.materialkolor:material-kolor", "MaterialKolor"),
+            library("com.materialkolor:material-kolor-jvm", "MaterialKolor"),
+            library("com.materialkolor:material-color-utilities", "MaterialKolor"),
+            library("com.materialkolor:material-color-utilities-jvm", "MaterialKolor"),
+        )
+
+        val result = libraries.processDuplicates(DuplicateMode.MERGE, DuplicateRule.EXACT)
+
+        assertEquals(
+            setOf("com.materialkolor:material-kolor", "com.materialkolor:material-color-utilities"),
+            result.map { it.uniqueId }.toSet(),
+        )
+    }
+
+    @Test
+    fun `platform artifacts of the same module are still merged`() {
+        val libraries = listOf(
+            library("androidx.collection:collection-jvm", "collection"),
+            library("androidx.collection:collection", "collection"),
+            library("androidx.collection:collection-js", "collection"),
+        )
+
+        val result = libraries.processDuplicates(DuplicateMode.MERGE, DuplicateRule.EXACT)
+
+        assertEquals(listOf("androidx.collection:collection"), result.map { it.uniqueId })
+    }
+}


### PR DESCRIPTION
## Problem

Reported in https://github.com/mikepenz/AboutLibraries/issues/1430#issuecomment-5370020486: `com.materialkolor:material-kolor:5.0.0` is reported as `com.materialkolor:material-color-utilities` in the generated JSON.

Not a `mergePlatformArtifacts` bug — reproduces with the option both on and off.

`DuplicateMode.MERGE` (the default) groups libraries by `DuplicateRule.EXACT` = `groupId + name + description`. Both MaterialKolor modules publish `<name>MaterialKolor</name>` with the same `<description>` under `com.materialkolor`, so all four coordinates (`material-kolor`, `material-kolor-jvm`, `material-color-utilities`, `material-color-utilities-jvm`) landed in one group. The survivor was picked by shortest name → tie → arbitrary list order, and one real library was silently dropped.

Any project sharing one POM `name`/`description` across sibling modules hits this.

## Fix

After the duplicate rule groups libraries, sub-cluster each group by module id: a member joins a cluster only when its module name is the cluster root plus a suffix. Platform variants of one module still merge (`collection` + `collection-jvm`), sibling modules no longer do.

The survivor selection now breaks name-length ties on the shortest `uniqueId`, so the root module is the deterministic survivor of a KMP merge instead of whichever platform artifact the graph walk reached first. Side benefit: the reported id matches the declared coordinate even with `mergePlatformArtifacts = false`, which also addresses the earlier complaint in #1430.

## Tests

- new `LibraryUtilTest` — regression case (sibling modules kept apart) plus the still-merges case
- `KmpAndroidFunctionalTest` / `MergePlatformArtifactsFunctionalTest` updated: both asserted the old arbitrary `-jvm` survivor
- full plugin suite green