### PR TITLE
fix(plugin): only merge artifact suffixes that name a Kotlin target

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
+++ b/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtil.kt
@@ -85,11 +85,34 @@ private fun List<Library>.clusterByArtifactId(): List<List<Library>> {
     val clusters = mutableListOf<Pair<String, MutableList<Library>>>() // root module -> members
     for (library in sortedBy { it.module().length }) {
         val module = library.module()
-        val cluster = clusters.firstOrNull { (root, _) -> module.startsWith("$root-") }
+        val cluster = clusters.firstOrNull { (root, _) -> module.isPlatformArtifactOf(root) }
         if (cluster != null) cluster.second += library else clusters += module to mutableListOf(library)
     }
     return clusters.map { it.second }
 }
+
+/**
+ * Kotlin target names as they appear in a published artifact id, lowercased: the fixed targets, the
+ * Compose/Kotlin publication suffixes, and the native target families (`linuxx64`,
+ * `iossimulatorarm64`, `watchosdevicearm64`, …).
+ */
+private val PLATFORM_SUFFIX = Regex(
+    "jvm[a-z0-9]*|android|js|wasm-?(js|wasi)|desktop|uikit|native|metadata|common|" +
+        "(linux|mingw|macos|ios|watchos|tvos|androidnative)[a-z0-9]*"
+)
+
+/**
+ * Whether this module id looks like a platform artifact of [root] — the root id plus a Kotlin
+ * target suffix (`collection` → `collection-jvm`).
+ *
+ * Matching the suffix against known target names rather than accepting any suffix is what keeps a
+ * sibling module from being swallowed by a shorter one it happens to share a prefix with
+ * (`androidx.core:core` must not absorb `core-ktx`, a `com.foo:android` module must not absorb
+ * `android-core`). An unknown target name degrades to reporting the artifact separately, which is
+ * the same output as before merging — never to a wrong merge.
+ */
+private fun String.isPlatformArtifactOf(root: String): Boolean =
+    startsWith("$root-") && PLATFORM_SUFFIX.matches(substring(root.length + 1))
 
 fun Library.merge(with: Library) {
     val orgLib = this

--- a/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtilTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/com/mikepenz/aboutlibraries/plugin/util/LibraryUtilTest.kt
@@ -160,4 +160,55 @@ class LibraryUtilTest {
 
         assertEquals(libraries.map { it.uniqueId }.toSet(), result.map { it.uniqueId }.toSet())
     }
+
+    @Test
+    fun `native and web platform artifacts are merged too`() {
+        val libraries = listOf(
+            library("androidx.collection:collection", "collection"),
+            library("androidx.collection:collection-iossimulatorarm64", "collection"),
+            library("androidx.collection:collection-linuxx64", "collection"),
+            library("androidx.collection:collection-wasm-js", "collection"),
+            library("androidx.collection:collection-jvmstubs", "collection"),
+            library("androidx.collection:collection-desktop", "collection"),
+        )
+
+        val result = libraries.processDuplicates(DuplicateMode.MERGE, DuplicateRule.EXACT)
+
+        assertEquals(listOf("androidx.collection:collection"), result.map { it.uniqueId })
+    }
+
+    /**
+     * A sibling module whose id happens to start with a shorter module's id is not a platform
+     * artifact of it — only a known Kotlin target suffix makes one.
+     */
+    @Test
+    fun `a shorter sibling module does not absorb the ones it prefixes`() {
+        val libraries = listOf(
+            library("com.foo:android", "Foo"),
+            library("com.foo:android-core", "Foo"),
+            library("com.foo:android-core-jvm", "Foo"),
+            library("com.foo:android-extra", "Foo"),
+            library("com.foo:android-extra-jvm", "Foo"),
+        )
+
+        val result = libraries.processDuplicates(DuplicateMode.MERGE, DuplicateRule.EXACT)
+
+        assertEquals(
+            setOf("com.foo:android", "com.foo:android-core", "com.foo:android-extra"),
+            result.map { it.uniqueId }.toSet(),
+            "each module keeps its own entry, absorbing only its own platform artifact",
+        )
+    }
+
+    @Test
+    fun `a non-target suffix is not treated as a platform artifact`() {
+        val libraries = listOf(
+            library("androidx.core:core", "Core"),
+            library("androidx.core:core-ktx", "Core"),
+        )
+
+        val result = libraries.processDuplicates(DuplicateMode.MERGE, DuplicateRule.EXACT)
+
+        assertEquals(libraries.map { it.uniqueId }.toSet(), result.map { it.uniqueId }.toSet())
+    }
 }


### PR DESCRIPTION
Stacked on #1453 — both touch `LibraryUtilTest.kt`. Retarget to `develop` once #1453 merges.

Follow-up to #1452, which is already merged.

## Problem

The clustering in #1452 accepted *any* suffix after a shorter module id, so a sibling module was swallowed by one it happened to share a prefix with. Measured, with every input sharing group + name + description:

| input | before | after |
|---|---|---|
| `android`, `android-core`, `android-core-jvm`, `android-extra`, `android-extra-jvm` | `android` | `android`, `android-core`, `android-extra` |
| `core`, `core-ktx` | `core` | `core`, `core-ktx` |
| `android-core`, `android-extra`, `android-core-jvm`, `android-extra-jvm` | already correct | unchanged |

The `core` / `core-ktx` collapse predates #1452 — both were already in one group under every rule.

## Fix

A member joins a cluster only when the remainder after the root is a Kotlin target name as published: `jvm`, `jvmstubs`, `android`, `js`, `wasm-js`, `wasm-wasi`, `desktop`, `uikit`, `native`, `metadata`, `common`, and the native families (`linuxx64`, `mingwx64`, `macosarm64`, `iossimulatorarm64`, `watchosdevicearm64`, `tvosarm64`, `androidnativearm32`).

An unrecognized target name degrades to reporting the artifact separately — the same output as before merging existed — never to a wrong merge. The list needs a line when Kotlin adds a target.

## Tests

Three cases added to `LibraryUtilTest` (11 total): native/web/`jvmstubs`/`desktop` suffixes still merge; a shorter sibling no longer absorbs the modules it prefixes; a non-target suffix (`-ktx`) is not a platform artifact.

Full plugin suite green.