### PR TITLE
chore(deps): update dependencies (Compose 1.12.0)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 ### Upgrade Notes
 
-#### Unreleased
+#### v15.2.0
 
 - **Dependency Upgrade**: Compose 1.12.x
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 ### Upgrade Notes
 
+#### Unreleased
+
+- **Dependency Upgrade**: Compose 1.12.x
+
 #### v15.1.0
 
 - **Breaking Change (Gradle Plugin)**: The Gradle plugin now targets Java 17 (previously Java 11), following AGP 9.3.1 which raised its own JVM target to 17.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Tapping a library opens its details — inline, in a dialog, or in a bottom shee
 
 ## Latest releases 🛠
 
-- Compose 1.12.x | New UI | AGP 9 | Kotlin 2.4 | Compile 37 | (unreleased, `develop`)
+- Compose 1.12.x | New UI | AGP 9 | Kotlin 2.4 | Compile 37 | [v15.2.0](https://github.com/mikepenz/AboutLibraries/tree/15.2.0)
 - Compose 1.11.x | New UI | AGP 9 | Kotlin 2.4 | Compile 37 | [v15.1.1](https://github.com/mikepenz/AboutLibraries/tree/15.1.1)
 - Compose 1.10.x | AGP 9 | [v14.1.0](https://github.com/mikepenz/AboutLibraries/tree/14.1.0)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Tapping a library opens its details — inline, in a dialog, or in a bottom shee
 
 ## Latest releases 🛠
 
+- Compose 1.12.x | New UI | AGP 9 | Kotlin 2.4 | Compile 37 | (unreleased, `develop`)
 - Compose 1.11.x | New UI | AGP 9 | Kotlin 2.4 | Compile 37 | [v15.1.1](https://github.com/mikepenz/AboutLibraries/tree/15.1.1)
 - Compose 1.10.x | AGP 9 | [v14.1.0](https://github.com/mikepenz/AboutLibraries/tree/14.1.0)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,13 +7,13 @@ cardview = "1.0.0"
 constraintLayout = "2.2.2"
 core = "1.19.0"
 lifecycle = { require = "2.11.0" }
-navigation = "2.9.8"
+navigation = "2.10.0"
 recyclerView = "1.4.0"
 # google
 material = "1.14.0"
 # other
 fastAdapter = "5.7.0"
-iconics = "5.5.0"
+iconics = "5.6.0"
 itemAnimators = "1.1.0"
 ivy = "2.6.0"
 modelBuilder = "3.9.16"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/plugin-build/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
             from(files("../gradle/libs.versions.toml"))
         }
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.19.0")
+            from("com.mikepenz:version-catalog:0.20.0")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.19.0")
+            from("com.mikepenz:version-catalog:0.20.0")
         }
     }
 }


### PR DESCRIPTION
## Summary
- via `com.mikepenz:version-catalog` 0.19.0 -> 0.20.0: Compose 1.11.4 -> 1.12.0, screenshot 0.0.1-alpha15 -> 0.0.1-alpha16, versionCatalogUpdate 1.1.0 -> 1.1.1, composablePreviewScanner 0.9.1 -> 0.9.2
- navigation 2.9.8 -> 2.10.0, iconics 5.5.0 -> 5.6.0, gradle wrapper 9.7.0 -> 9.7.1
- README/MIGRATION updated to reference the upcoming v15.2.0 release for the Compose 1.12.x upgrade

## Test plan
- [ ] `./gradlew build`
- [ ] `./gradlew apiCheck`